### PR TITLE
Automatic File Generation and Extended Configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This extension contributes the following settings:
 * `alOutline.autorefresh`: refresh code outline tree automatically
 * `alOutline.autoGenerateFiles`: automatically generate files for newly created objects
 * `alOutline.autoGenerateFileDirectory`: the default directory to create files in, relative to the root directory (e.g., \"Source\<ObjectType\>\")
+* `alOutline.autoShowFiles`: automatically show any newly created files in the editor
 * `alOutline.defaultAppArea`: default application area for page code generator
 * `alOutline.defaultListUsageCategory`: default usage category for list pages
 * `alOutline.extensionObjectFileNamePattern`: default file naming pattern for new extension objects

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This extension contributes the following settings:
 * `alOutline.defaultListUsageCategory`: default usage category for list pages
 * `alOutline.extensionObjectFileNamePattern`: default file naming pattern for new extension objects
 * `alOutline.extensionObjectNamePattern`: default naming pattern for new extension objects
-* `alOutline.fullObjectFileNamePattern`: default naming pattern for new extension objects
+* `alOutline.fullObjectFileNamePattern`: default file naming pattern for new full objects
 * `alOutline.promptForObjectId`: when generating a new object, ask the user to input the object ID.
 * `alOutline.promptForObjectName`: when generating a new object, ask the user to input the object name
 * `alOutline.promptForFilePath`: when generating a new file, ask the user to specify a path relative to the root of the project-folder

--- a/README.md
+++ b/README.md
@@ -29,8 +29,17 @@ This extension has been inspired by "Code Outline" extension created by Patryk Z
 This extension contributes the following settings:
 
 * `alOutline.autorefresh`: refresh code outline tree automatically
+* `alOutline.autoGenerateFiles`: automatically generate files for newly created objects
+* `alOutline.autoGenerateFileDirectory`: the default directory to create files in, relative to the root directory (e.g., \"Source\<ObjectType\>\")
 * `alOutline.defaultAppArea`: default application area for page code generator
 * `alOutline.defaultListUsageCategory`: default usage category for list pages
+* `alOutline.extensionObjectFileNamePattern`: default file naming pattern for new extension objects
+* `alOutline.extensionObjectNamePattern`: default naming pattern for new extension objects
+* `alOutline.fullObjectFileNamePattern`: default naming pattern for new extension objects
+* `alOutline.promptForObjectId`: when generating a new object, ask the user to input the object ID.
+* `alOutline.promptForObjectName`: when generating a new object, ask the user to input the object name
+* `alOutline.promptForFilePath`: when generating a new file, ask the user to specify a path relative to the root of the project-folder
+* `alOutline.stripNonAlphanumericCharactersFromObjectNames`: always strip non-alphanumeric characters from generated object names
 * `alOutline.webClientPort`: web client port number, use 0 for default http/https ports
 
 ## Known Issues

--- a/package.json
+++ b/package.json
@@ -161,6 +161,11 @@
 						"default": "",
 						"description": "The default directory to create files in, relative to the root directory (e.g., \"Source\\<ObjectType>\")."
 					},
+					"alOutline.autoShowFiles": {
+						"type": "boolean",
+						"default": true,
+						"description": "Automatically show any newly created files in the editor."
+					},
 					"alOutline.defaultAppArea": {
 						"type": "string",
 						"default": "All",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
 					"alOutline.autoGenerateFileDirectory": {
 						"type": "string",
 						"default": "",
-						"description": "The default directory to create files in relative to the root directory (e.g., \"Source\\<ObjectType>\")."
+						"description": "The default directory to create files in, relative to the root directory (e.g., \"Source\\<ObjectType>\")."
 					},
 					"alOutline.defaultAppArea": {
 						"type": "string",

--- a/package.json
+++ b/package.json
@@ -151,6 +151,16 @@
 						"default": true,
 						"description": "Refresh code outline tree automatically"
 					},
+					"alOutline.autoGenerateFiles": {
+						"type": "boolean",
+						"default": true,
+						"description": "Automatically generate files for newly created objects."
+					},
+					"alOutline.autoGenerateFileDirectory": {
+						"type": "string",
+						"default": "",
+						"description": "The default directory to create files in relative to the root directory (e.g., \"Source\\<ObjectType>\")."
+					},
 					"alOutline.defaultAppArea": {
 						"type": "string",
 						"default": "All",
@@ -160,6 +170,41 @@
 						"type": "string",
 						"default": "Lists",
 						"description": "Default usage category for list pages"
+					},
+					"alOutline.extensionObjectFileNamePattern": {
+						"type": "string",
+						"default": "<ObjectTypeShort><BaseId>-Ext<ObjectId>.<ObjectName>",
+						"description": "Default file naming pattern for new extension objects."
+					},
+					"alOutline.extensionObjectNamePattern": {
+						"type": "string",
+						"default": "<BaseName>Ext",
+						"description": "Default naming pattern for new extension objects."
+					},
+					"alOutline.fullObjectFileNamePattern": {
+						"type": "string",
+						"default": "<ObjectTypeShort><ObjectId>.<ObjectName>",
+						"description": "Default file naming pattern for new full objects."
+					},
+					"alOutline.promptForObjectId": {
+						"type": "boolean",
+						"default": true,
+						"description": "When generating a new object, ask the user to input the object ID."
+					},
+					"alOutline.promptForObjectName": {
+						"type": "boolean",
+						"default": true,
+						"description": "When generating a new object, ask the user to input the object name."
+					},
+					"alOutline.promptForFilePath": {
+						"type": "boolean",
+						"default": false,
+						"description": "When generating a new file, ask the user to specify a path relative to the root of the project-folder."
+					},
+					"alOutline.stripNonAlphanumericCharactersFromObjectNames": {
+						"type": "boolean",
+						"default": false,
+						"description": "Always strip non-alphanumeric characters from generated object names."
 					},
 					"alOutline.webClientPort": {
 						"type": "number",

--- a/src/objectbuilders/alObjectWriter.ts
+++ b/src/objectbuilders/alObjectWriter.ts
@@ -64,7 +64,10 @@ export class ALObjectWriter {
         else
             objectIdText = id.toString();
         
-        this.writeLine(type + " " + objectIdText + " \"" + name.replace("\"", "\"\"") + "\"");
+        name = name.replace("\"", "\"\"");
+        name = this.escapeObjectName(name);
+
+        this.writeLine(type + " " + objectIdText + " " + name);
         this.writeStartBlock();
     }
 
@@ -75,7 +78,12 @@ export class ALObjectWriter {
         else
             objectIdText = id.toString();
         
-        this.writeLine(type + " " + objectIdText + " \"" + extname.replace("\"", "\"\"") + "\"" + " extends " + "\"" + targetName + "\"");
+        extname = extname.replace("\"", "\"\"");
+        extname = this.escapeObjectName(extname);
+        targetName = this.escapeObjectName(targetName);
+
+        this.writeLine(type + " " + objectIdText + " " + extname + " extends " + targetName);
+        
         this.writeStartBlock();
     }
 
@@ -136,6 +144,13 @@ export class ALObjectWriter {
 
     public encodeName(name : string) : string {
         return "\"" + name.replace("\"", "\"\"") + "\"";
+    }
+
+    public escapeObjectName(name : string) : string {
+        if (/\W/.test(name)) {
+            name = "\"" + name + "\"";
+        }
+        return name;
     }
 
     public createName(source : string) : string {

--- a/src/objectbuilders/fileBuilder.ts
+++ b/src/objectbuilders/fileBuilder.ts
@@ -1,0 +1,187 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { ALSymbolKind } from '../alSymbolKind';
+import { ALSymbolInfo } from '../alSymbolInfo';
+
+export class FileBuilder {
+    public static async generateObjectFile(content: string, fileName: string, objectType: ALSymbolKind): Promise<string | undefined> {
+        // Determine the project root directory.
+        let workspaceFolderCount: number = vscode.workspace.workspaceFolders.length;
+        if (workspaceFolderCount < 1) {
+            return undefined;
+        }
+
+        let workspaceFolder: vscode.WorkspaceFolder = null;
+        if (workspaceFolderCount == 1) {
+            workspaceFolder = vscode.workspace.workspaceFolders[0];
+        }
+        else {
+            workspaceFolder = await vscode.window.showWorkspaceFolderPick();
+        }
+        if (!workspaceFolder || workspaceFolder.uri.scheme !== 'file') {
+            return undefined;
+        }
+
+        // Determine the directory to place the files in; create the directory if it does not exist yet.
+        const baseFileDir : string = workspaceFolder.uri.fsPath;
+        let relativeFileDir : string = this.getPatternGeneratedRelativeFilePath(objectType);
+
+        const promptForFilePath: boolean = vscode.workspace.getConfiguration('alOutline').get('promptForFilePath');
+        if (promptForFilePath) {
+            relativeFileDir = await vscode.window.showInputBox({
+                value  : relativeFileDir,
+                prompt : 'Please enter a directory, relative to the root, to create the new file in.',
+                ignoreFocusOut: true
+            });
+        }
+        
+        const newFileDirectory : string = path.join(baseFileDir, relativeFileDir);
+
+        if (relativeFileDir) {
+            try {
+                if (!fs.existsSync(newFileDirectory)) {
+                    this.mkdirRecursiveSync(baseFileDir, relativeFileDir);
+                }
+            }
+            catch (err) {
+                vscode.window.showErrorMessage('Could not create the path due to the following error: ' + err);
+                return undefined;
+            }
+        }
+        
+        
+        // Determine the file path for the new file to generate. Do not overwrite the file if it already exists.
+        const newFilePath : string = path.join(newFileDirectory, fileName);
+        const fileAlreadyExists = await this.fileExists(newFilePath);
+        if (!fileAlreadyExists) {
+            fs.appendFileSync(newFilePath, content);
+        }
+        return newFilePath;
+    }
+
+    private static mkdirRecursiveSync(baseDir:string, relativeDir: string) {
+        relativeDir.split(/[\/\\]/g).reduce((prevDirPath, dirToCreate) => {
+            const curDirPathToCreate = path.resolve(baseDir, prevDirPath, dirToCreate);
+            try {
+                fs.mkdirSync(curDirPathToCreate);
+            } 
+            catch (err) {
+                if (err.code !== 'EEXIST') {
+                    throw err;
+                }
+            }
+    
+            return curDirPathToCreate;
+        }, '');
+    }
+
+    private static fileExists(path: string): Promise<boolean> {
+        return new Promise((resolve, reject) => {
+          fs.exists(path, exists => {
+            resolve(exists);
+          });
+        });
+    }
+
+    //#region Object / File Pattern
+
+    public static getPatternGeneratedExtensionObjectName(extensionType: ALSymbolKind, extensionId: number, baseSymbolInfo: ALSymbolInfo) {
+        let pattern: string = vscode.workspace.getConfiguration('alOutline').get('extensionObjectNamePattern');
+        let objectName: string = this.replaceAllExtensionPatterns(pattern, extensionType, extensionId, '', baseSymbolInfo);
+
+        let stripChars: string = vscode.workspace.getConfiguration('alOutline').get('stripNonAlphanumericCharactersFromObjectNames');
+        if (stripChars) {
+            objectName = this.stripNonAlphaNumericCharacters(objectName);
+        }
+        return objectName;
+    }
+
+    public static getPatternGeneratedExtensionObjectFileName(extensionType: ALSymbolKind, extensionId: number, extensionObjectName: string, baseSymbolInfo: ALSymbolInfo) {
+        let pattern: string = vscode.workspace.getConfiguration('alOutline').get('extensionObjectFileNamePattern');
+        return this.replaceAllExtensionPatterns(pattern, extensionType, extensionId, extensionObjectName, baseSymbolInfo) + '.al';
+    }
+
+    private static replaceAllExtensionPatterns(pattern: string, extensionType: ALSymbolKind, extensionId: number, extensionObjectName: string, baseSymbolInfo: ALSymbolInfo) {
+        let output = pattern;
+
+        output = this.replacePattern(output, '<ObjectType>', this.getObjectTypeFromSymbolInfo(extensionType));
+        output = this.replacePattern(output, '<ObjectTypeShort>', this.getObjectTypeAbbreviation(extensionType));
+        output = this.replacePattern(output, '<ObjectId>', extensionId.toString());
+        if (extensionObjectName) {
+            output = this.replacePattern(output, '<ObjectName>', this.stripNonAlphaNumericCharacters(extensionObjectName));
+        }
+        output = this.replacePattern(output, '<BaseName>', this.getObjectNameFromSymbolInfo(baseSymbolInfo));
+        output = this.replacePattern(output, '<BaseId>', this.getObjectIdFromSymbolInfo(baseSymbolInfo).toString());
+
+        return output;
+    }
+
+    private static getPatternGeneratedRelativeFilePath(objectType: ALSymbolKind) {
+        let output: string = vscode.workspace.getConfiguration('alOutline').get('autoGenerateFileDirectory');
+        
+        output = this.replacePattern(output, '<ObjectType>', this.getObjectTypeFromSymbolInfo(objectType));
+        output = this.replacePattern(output, '<ObjectTypeShort>', this.getObjectTypeAbbreviation(objectType));
+
+        return output;
+    } 
+
+    private static getObjectIdFromSymbolInfo(alSymbolInfo: ALSymbolInfo): number {
+        return alSymbolInfo.alElementId;
+    }
+
+    private static getObjectNameFromSymbolInfo(alSymbolInfo: ALSymbolInfo): string {
+        return this.stripNonAlphaNumericCharacters(alSymbolInfo.symbolName);
+    }
+
+    private static getObjectTypeFromSymbolInfo(alSymbolKind: ALSymbolKind): string {
+        return ALSymbolKind[alSymbolKind];
+    }
+
+    private static getObjectTypeAbbreviation(alSymbolKind: ALSymbolKind): string {
+        switch (alSymbolKind) {
+            case ALSymbolKind.Table: return 'Tab';
+            case ALSymbolKind.Page: return 'Pag';
+            case ALSymbolKind.Report: return 'Rep';
+            case ALSymbolKind.XmlPort: return 'Xml';
+            case ALSymbolKind.Query: return 'Que';
+            case ALSymbolKind.Codeunit: return 'Cod';
+            case ALSymbolKind.PageExtension: return 'Pag';
+            case ALSymbolKind.TableExtension: return 'Tab';
+            case ALSymbolKind.Profile: return 'Prof';
+            case ALSymbolKind.PageCustomization: return 'Pag';
+            case ALSymbolKind.Enum: return 'Enu';
+            case ALSymbolKind.EnumExtension: return 'Enu';
+            case ALSymbolKind.DotNetPackage: return 'DotNet';
+            default: return "";
+        }
+    }
+
+    private static replacePattern(name: string, pattern: string, replaceWith: string) {
+        return name.replace(new RegExp(this.escapeRegExpInPattern(pattern), 'g'), replaceWith);
+    }
+
+    /**
+    * Escapes any regex operators/characters in a string.
+    * 
+    * For further reference, please see [this](https://stackoverflow.com/questions/3446170/escape-string-for-use-in-javascript-regex) StackOverflow page.
+    * 
+    * @param {string} name The string in which to escape all regex characters.
+    * @returns The input string with any regex characters escaped.
+    */
+    private static escapeRegExpInPattern(name: string)  {
+        return name.replace(/([.*+?^${}()|\[\]\/\\=!:])/g, "\\$1");
+    }
+
+    /**
+     * Removes any characters that are not in the alphabet (\[A-Za-z\]), are numbers (\[0-9\]), or the underscore character ('_').
+     * 
+     * @param {string} name The string from which to strip characters.
+     * @returns The input string with any non-alphameric characters removed.
+     */
+    public static stripNonAlphaNumericCharacters(name: string): string {
+        return name.replace(/\W/g,"");
+    }
+
+    //#endregion
+}

--- a/src/objectbuilders/fileBuilder.ts
+++ b/src/objectbuilders/fileBuilder.ts
@@ -31,7 +31,7 @@ export class FileBuilder {
         if (promptForFilePath) {
             relativeFileDir = await vscode.window.showInputBox({
                 value  : relativeFileDir,
-                prompt : 'Please enter a directory, relative to the root, to create the new file in.',
+                prompt : 'Please specify a directory, relative to the root, to create the new file in.',
                 ignoreFocusOut: true
             });
         }
@@ -86,7 +86,25 @@ export class FileBuilder {
 
     //#region Object / File Pattern
 
-    public static getPatternGeneratedExtensionObjectName(extensionType: ALSymbolKind, extensionId: number, baseSymbolInfo: ALSymbolInfo) {
+    public static getPatternGeneratedFullObjectFileName(objectType: ALSymbolKind, objectId: number, objectName: string) : string {
+        let pattern: string = vscode.workspace.getConfiguration('alOutline').get('fullObjectFileNamePattern');
+        return this.replaceAllFullObjPatterns(pattern, objectType, objectId, objectName) + '.al';
+    }
+
+    private static replaceAllFullObjPatterns(pattern: string, objectType: ALSymbolKind, objectId: number, objectName: string) : string {
+        let output = pattern;
+
+        output = this.replacePattern(output, '<ObjectType>', this.getObjectTypeFromSymbolInfo(objectType));
+        output = this.replacePattern(output, '<ObjectTypeShort>', this.getObjectTypeAbbreviation(objectType));
+        output = this.replacePattern(output, '<ObjectId>', objectId.toString());
+        if (objectName) {
+            output = this.replacePattern(output, '<ObjectName>', this.stripNonAlphaNumericCharacters(objectName));
+        }
+
+        return output;
+    }
+
+    public static getPatternGeneratedExtensionObjectName(extensionType: ALSymbolKind, extensionId: number, baseSymbolInfo: ALSymbolInfo) : string {
         let pattern: string = vscode.workspace.getConfiguration('alOutline').get('extensionObjectNamePattern');
         let objectName: string = this.replaceAllExtensionPatterns(pattern, extensionType, extensionId, '', baseSymbolInfo);
 
@@ -97,12 +115,12 @@ export class FileBuilder {
         return objectName;
     }
 
-    public static getPatternGeneratedExtensionObjectFileName(extensionType: ALSymbolKind, extensionId: number, extensionObjectName: string, baseSymbolInfo: ALSymbolInfo) {
+    public static getPatternGeneratedExtensionObjectFileName(extensionType: ALSymbolKind, extensionId: number, extensionObjectName: string, baseSymbolInfo: ALSymbolInfo) : string {
         let pattern: string = vscode.workspace.getConfiguration('alOutline').get('extensionObjectFileNamePattern');
         return this.replaceAllExtensionPatterns(pattern, extensionType, extensionId, extensionObjectName, baseSymbolInfo) + '.al';
     }
 
-    private static replaceAllExtensionPatterns(pattern: string, extensionType: ALSymbolKind, extensionId: number, extensionObjectName: string, baseSymbolInfo: ALSymbolInfo) {
+    private static replaceAllExtensionPatterns(pattern: string, extensionType: ALSymbolKind, extensionId: number, extensionObjectName: string, baseSymbolInfo: ALSymbolInfo) : string {
         let output = pattern;
 
         output = this.replacePattern(output, '<ObjectType>', this.getObjectTypeFromSymbolInfo(extensionType));
@@ -113,11 +131,13 @@ export class FileBuilder {
         }
         output = this.replacePattern(output, '<BaseName>', this.getObjectNameFromSymbolInfo(baseSymbolInfo));
         output = this.replacePattern(output, '<BaseId>', this.getObjectIdFromSymbolInfo(baseSymbolInfo).toString());
+        output = this.replacePattern(output, '<BaseType>', this.getObjectTypeFromSymbolInfo(baseSymbolInfo.alKind));
+        output = this.replacePattern(output, '<BaseTypeShort>', this.getObjectTypeAbbreviation(baseSymbolInfo.alKind));
 
         return output;
     }
 
-    private static getPatternGeneratedRelativeFilePath(objectType: ALSymbolKind) {
+    private static getPatternGeneratedRelativeFilePath(objectType: ALSymbolKind) : string {
         let output: string = vscode.workspace.getConfiguration('alOutline').get('autoGenerateFileDirectory');
         
         output = this.replacePattern(output, '<ObjectType>', this.getObjectTypeFromSymbolInfo(objectType));
@@ -157,7 +177,7 @@ export class FileBuilder {
         }
     }
 
-    private static replacePattern(name: string, pattern: string, replaceWith: string) {
+    private static replacePattern(name: string, pattern: string, replaceWith: string) : string {
         return name.replace(new RegExp(this.escapeRegExpInPattern(pattern), 'g'), replaceWith);
     }
 

--- a/src/objectbuilders/objectBuilder.ts
+++ b/src/objectbuilders/objectBuilder.ts
@@ -1,11 +1,45 @@
 import * as vscode from 'vscode';
+import { ALSymbolKind } from '../alSymbolKind';
+import { FileBuilder } from './fileBuilder';
 
 export class ObjectBuilder {
     
     constructor() {
     }
 
-    protected showNewDocument(content : string) {
+    protected showNewDocument(content : string, fileName?: string, objectType?: ALSymbolKind) {
+        let autoGenerateFile: boolean = vscode.workspace.getConfiguration('alOutline').get('autoGenerateFiles');
+        if (autoGenerateFile && fileName) {
+            this.showNewGeneratedFile(content, fileName, objectType);
+        }
+        else {
+            this.showNewUntitledDocument(content);
+        }
+    }
+
+    private showNewGeneratedFile(content : string, fileName : string, objectType : ALSymbolKind) {
+        FileBuilder.generateObjectFile(content, fileName, objectType).then(
+            path => {
+                if (path) {
+                    vscode.workspace.openTextDocument(path).then(
+                        document => {
+                            vscode.window.showTextDocument(document, {
+                                preview : false
+                            });
+                        },
+                        err => {
+                            vscode.window.showErrorMessage(err);
+                        }
+                    );
+                }
+            },
+            err => {
+                vscode.window.showErrorMessage(err);
+            }
+        );
+    }
+
+    private showNewUntitledDocument(content: string) {
         vscode.workspace.openTextDocument({
             content : content,
             language : "al"
@@ -19,5 +53,4 @@ export class ObjectBuilder {
                 vscode.window.showErrorMessage(err);
             });
     }
-
 }

--- a/src/objectbuilders/objectBuilder.ts
+++ b/src/objectbuilders/objectBuilder.ts
@@ -23,9 +23,12 @@ export class ObjectBuilder {
                 if (path) {
                     vscode.workspace.openTextDocument(path).then(
                         document => {
-                            vscode.window.showTextDocument(document, {
-                                preview : false
-                            });
+                            let autoShowDocument: boolean = vscode.workspace.getConfiguration('alOutline').get('autoShowFiles');
+                            if (autoShowDocument) {
+                                vscode.window.showTextDocument(document, {
+                                    preview : false
+                                });
+                            }
                         },
                         err => {
                             vscode.window.showErrorMessage(err);

--- a/src/objectbuilders/objectBuilder.ts
+++ b/src/objectbuilders/objectBuilder.ts
@@ -53,4 +53,82 @@ export class ObjectBuilder {
                 vscode.window.showErrorMessage(err);
             });
     }
+
+    protected async getObjectId(promptText: string, defaultObjectId: number) : Promise<number> {
+        let objectIdString : string = defaultObjectId.toString();
+        if (this.shouldPromptForObjectId()) {
+            objectIdString = await this.promptForObjectId(promptText, objectIdString);
+        }
+
+        if (!objectIdString) {
+            objectIdString = "0";
+        }
+        
+        let objectId : number = Number(objectIdString);
+        if (isNaN(objectId)) {
+            return 0;
+        }
+
+        return objectId;
+    }
+
+    protected async getObjectName(promptText: string, defaultObjectName : string) : Promise<string | undefined> {
+        let objectName : string = defaultObjectName;
+        if (this.shouldPromptForObjectName()) {
+            objectName = await this.promptForObjectName(promptText, objectName);
+        }
+
+        if (!objectName) {
+            return objectName;
+        }
+
+        if (this.shouldStripCharacters()) {
+            objectName = FileBuilder.stripNonAlphaNumericCharacters(objectName);
+        }
+
+        return objectName;
+    }
+
+    //#region UI functions
+
+    private promptForObjectId(promptText: string, defaultObjectId : string) : Thenable<string | undefined> {
+        return vscode.window.showInputBox({
+            value : defaultObjectId,
+            prompt : promptText,
+            validateInput: (text: string): string | undefined => {
+                let objectId : number = Number(text);
+                if (isNaN(objectId)) {
+                    return 'Only numbers are allowed for object IDs.'
+                }
+                else {
+                    return undefined;
+                }
+            }
+        });
+    }
+
+    private promptForObjectName(promptText: string, defaultObjectName : string) : Thenable<string | undefined> {
+        return vscode.window.showInputBox({
+            value : defaultObjectName,
+            prompt : promptText
+        });
+    }
+
+    //#endregion
+
+    //#region Setting Helper Functions
+
+    private shouldPromptForObjectId() : boolean {
+        return vscode.workspace.getConfiguration('alOutline').get('promptForObjectId');
+    }
+
+    private shouldPromptForObjectName() : boolean {
+        return vscode.workspace.getConfiguration('alOutline').get('promptForObjectName');
+    }
+
+    private shouldStripCharacters() : boolean {
+        return vscode.workspace.getConfiguration('alOutline').get('stripNonAlphanumericCharactersFromObjectNames');
+    }
+
+    //#endregion
 }

--- a/src/objectbuilders/pageBuilder.ts
+++ b/src/objectbuilders/pageBuilder.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { ALObjectWriter } from "./alObjectWriter";
 import { ALSymbolInfo } from "../alSymbolInfo";
 import { ALSymbolKind } from "../alSymbolKind";
+import { FileBuilder } from './fileBuilder';
 import { ObjectBuilder } from './objectBuilder';
 
 export class PageBuilder extends ObjectBuilder {
@@ -13,33 +14,35 @@ export class PageBuilder extends ObjectBuilder {
     //#region Wizards with UI
 
     async showListPageWizard(tableSymbol : ALSymbolInfo) {
-        let objectName : string = await this.getPageName(
-            tableSymbol.symbolName.trim() + " List");
-        
-        if (!objectName)
-            return;
+        const objType : ALSymbolKind = ALSymbolKind.Page;
 
-        this.showNewDocument(this.buildListPageForTable(tableSymbol, 0, objectName));
+        let objectId : number = await this.getObjectId("Please enter an ID for the list page.", 0);
+
+        let objectName : string = tableSymbol.symbolName.trim() + " List";
+        objectName = await this.getObjectName("Please enter a name for the list page.", objectName);
+        
+        if (!objectName) {
+            return;
+        }
+
+        let fileName : string = FileBuilder.getPatternGeneratedFullObjectFileName(objType, objectId, objectName);
+        this.showNewDocument(this.buildListPageForTable(tableSymbol, objectId, objectName), fileName, objType);
     }
 
     async showCardPageWizard(tableSymbol : ALSymbolInfo) {
-        let objectName : string = await this.getPageName(
-            tableSymbol.symbolName.trim() + " Card");
+        const objType : ALSymbolKind = ALSymbolKind.Page;
+
+        let objectId : number = await this.getObjectId("Please enter an ID for the card page.", 0);
+
+        let objectName : string = tableSymbol.symbolName.trim() + " Card";
+        objectName = await this.getObjectName("Please enter a name for the card page.", objectName);
         
-        if (!objectName)
+        if (!objectName) {
             return;
+        }
 
-        this.showNewDocument(this.buildCardPageForTable(tableSymbol, 0, objectName));
-    }
-
-    //#endregion
-
-    //#region UI functions
-
-    private getPageName(defaultPageName : string) : Thenable<string> {
-        return vscode.window.showInputBox({
-            value : defaultPageName,
-            prompt : "Please enter new page name"});
+        let fileName : string = FileBuilder.getPatternGeneratedFullObjectFileName(objType, objectId, objectName);
+        this.showNewDocument(this.buildCardPageForTable(tableSymbol, objectId, objectName), fileName, objType);
     }
 
     //#endregion

--- a/src/objectbuilders/pageExtBuilder.ts
+++ b/src/objectbuilders/pageExtBuilder.ts
@@ -15,57 +15,17 @@ export class PageExtBuilder extends ObjectBuilder {
 
     async showPageExtWizard(pageSymbol : ALSymbolInfo) {
         const extObjType : ALSymbolKind = ALSymbolKind.PageExtension;
-
-        let extObjectIdString : string = "0";
-        let promptForObjectId: boolean = vscode.workspace.getConfiguration('alOutline').get('promptForObjectId');
-        if (promptForObjectId) {
-            extObjectIdString = await this.getPageExtId(extObjectIdString);
-        }
-
-        if (!extObjectIdString) {
-            extObjectIdString = "0";
-        }
         
-        let extObjectId : number = Number(extObjectIdString);
-        if (isNaN(extObjectId)) {
-            return;
-        }
+        let extObjectId : number = await this.getObjectId("Please enter an ID for the page extension.", 0);
 
         let extObjectName: string = FileBuilder.getPatternGeneratedExtensionObjectName(extObjType, extObjectId, pageSymbol);
-        let promptForObjectName: boolean = vscode.workspace.getConfiguration('alOutline').get('promptForObjectName');
-        if (promptForObjectName) {
-            extObjectName = await this.getPageExtName(extObjectName);
-        }
-        
+        extObjectName = await this.getObjectName("Please enter a name for the page extension.", extObjectName);
         if (!extObjectName) {
             return;
         }
 
-        let stripChars: string = vscode.workspace.getConfiguration('alOutline').get('stripNonAlphanumericCharactersFromObjectNames');
-        if (stripChars) {
-            extObjectName = FileBuilder.stripNonAlphaNumericCharacters(extObjectName);
-        }
-
         let fileName : string = FileBuilder.getPatternGeneratedExtensionObjectFileName(extObjType, extObjectId, extObjectName, pageSymbol);
         this.showNewDocument(this.buildPageExtForPage(pageSymbol, extObjectId, extObjectName), fileName, extObjType);
-    }
-
-    //#endregion
-
-    //#region UI functions
-
-    private getPageExtId(defaultExtName : string) : Thenable<string> {
-        return vscode.window.showInputBox({
-            value : defaultExtName,
-            prompt : "Please enter an id for the page extension."
-        });
-    }
-
-    private getPageExtName(defaultExtName : string) : Thenable<string> {
-        return vscode.window.showInputBox({
-            value : defaultExtName,
-            prompt : "Please enter a name for the page extension."
-        });
     }
 
     //#endregion

--- a/src/objectbuilders/queryBuilder.ts
+++ b/src/objectbuilders/queryBuilder.ts
@@ -1,8 +1,9 @@
 import * as vscode from 'vscode';
-import { ObjectBuilder } from "./objectBuilder";
-import { ALSymbolInfo } from "../alSymbolInfo";
 import { ALObjectWriter } from './alObjectWriter';
+import { ALSymbolInfo } from "../alSymbolInfo";
 import { ALSymbolKind } from '../alSymbolKind';
+import { FileBuilder } from './fileBuilder';
+import { ObjectBuilder } from "./objectBuilder";
 
 export class QueryBuilder extends ObjectBuilder {
 
@@ -13,23 +14,19 @@ export class QueryBuilder extends ObjectBuilder {
     //#region Wizards with UI
 
     async showQueryWizard(tableSymbol : ALSymbolInfo) {
-        let objectName : string = await this.getQueryName(
-            tableSymbol.symbolName.trim() + " Query");
+        const objType : ALSymbolKind = ALSymbolKind.Query;
+
+        let objectId : number = await this.getObjectId("Please enter an ID for the query object.", 0);
+
+        let objectName : string = tableSymbol.symbolName.trim() + " Query";
+        objectName = await this.getObjectName("Please enter a name for the query object.", objectName);
         
-        if (!objectName)
+        if (!objectName) {
             return;
+        }
 
-        this.showNewDocument(this.buildQueryForTable(tableSymbol, 0, objectName));
-    }
-
-    //#endregion
-    
-    //#region UI functions
-
-    private getQueryName(defaultName : string) : Thenable<string> {
-        return vscode.window.showInputBox({
-            value : defaultName,
-            prompt : "Please enter new query name"});
+        let fileName : string = FileBuilder.getPatternGeneratedFullObjectFileName(objType, objectId, objectName);
+        this.showNewDocument(this.buildQueryForTable(tableSymbol, objectId, objectName), fileName, objType);
     }
 
     //#endregion

--- a/src/objectbuilders/reportBuilder.ts
+++ b/src/objectbuilders/reportBuilder.ts
@@ -1,8 +1,9 @@
 import * as vscode from 'vscode';
-import { ObjectBuilder } from "./objectBuilder";
-import { ALSymbolInfo } from "../alSymbolInfo";
 import { ALObjectWriter } from './alObjectWriter';
+import { ALSymbolInfo } from "../alSymbolInfo";
 import { ALSymbolKind } from '../alSymbolKind';
+import { FileBuilder } from './fileBuilder';
+import { ObjectBuilder } from "./objectBuilder";
 
 export class ReportBuilder extends ObjectBuilder {
 
@@ -13,23 +14,19 @@ export class ReportBuilder extends ObjectBuilder {
     //#region Wizards with UI
 
     async showReportWizard(tableSymbol : ALSymbolInfo) {
-        let objectName : string = await this.getReportName(
-            tableSymbol.symbolName.trim() + " Report");
+        const objType : ALSymbolKind = ALSymbolKind.Report;
+
+        let objectId : number = await this.getObjectId("Please enter an ID for the report object.", 0);
+
+        let objectName : string = tableSymbol.symbolName.trim() + " Report";
+        objectName = await this.getObjectName("Please enter a name for the report object.", objectName);
         
-        if (!objectName)
+        if (!objectName) {
             return;
+        }
 
-        this.showNewDocument(this.buildReportForTable(tableSymbol, 0, objectName));
-    }
-
-    //#endregion
-
-    //#region UI functions
-
-    private getReportName(defaultName : string) : Thenable<string> {
-        return vscode.window.showInputBox({
-            value : defaultName,
-            prompt : "Please enter new report name"});
+        let fileName : string = FileBuilder.getPatternGeneratedFullObjectFileName(objType, objectId, objectName);
+        this.showNewDocument(this.buildReportForTable(tableSymbol, objectId, objectName), fileName, objType);
     }
 
     //#endregion

--- a/src/objectbuilders/tableExtBuilder.ts
+++ b/src/objectbuilders/tableExtBuilder.ts
@@ -16,56 +16,16 @@ export class TableExtBuilder extends ObjectBuilder {
     async showTableExtWizard(tableSymbol : ALSymbolInfo) {
         const extObjType : ALSymbolKind = ALSymbolKind.TableExtension;
 
-        let extObjectIdString : string = "0";
-        let promptForObjectId: boolean = vscode.workspace.getConfiguration('alOutline').get('promptForObjectId');
-        if (promptForObjectId) {
-            extObjectIdString = await this.getTableExtId(extObjectIdString);
-        }
-
-        if (!extObjectIdString) {
-            extObjectIdString = "0";
-        }
-        
-        let extObjectId : number = Number(extObjectIdString);
-        if (isNaN(extObjectId)) {
-            return;
-        }
+        let extObjectId : number = await this.getObjectId("Please enter an ID for the table extension.", 0);
 
         let extObjectName: string = FileBuilder.getPatternGeneratedExtensionObjectName(extObjType, extObjectId, tableSymbol);
-        let promptForObjectName: boolean = vscode.workspace.getConfiguration('alOutline').get('promptForObjectName');
-        if (promptForObjectName) {
-            extObjectName = await this.getTableExtName(extObjectName);
-        }
-        
+        extObjectName = await this.getObjectName("Please enter a name for the table extension.", extObjectName);
         if (!extObjectName) {
             return;
-        }
-
-        let stripChars: string = vscode.workspace.getConfiguration('alOutline').get('stripNonAlphanumericCharactersFromObjectNames');
-        if (stripChars) {
-            extObjectName = FileBuilder.stripNonAlphaNumericCharacters(extObjectName);
         }
         
         let fileName : string = FileBuilder.getPatternGeneratedExtensionObjectFileName(extObjType, extObjectId, extObjectName, tableSymbol);
         this.showNewDocument(this.buildTableExtForTable(tableSymbol, extObjectId, extObjectName), fileName, extObjType);
-    }
-
-    //#endregion
-
-    //#region UI functions
-
-    private getTableExtId(defaultExtName : string) : Thenable<string> {
-        return vscode.window.showInputBox({
-            value : defaultExtName,
-            prompt : "Please enter an id for the table extension."
-        });
-    }
-
-    private getTableExtName(defaultExtName : string) : Thenable<string> {
-        return vscode.window.showInputBox({
-            value : defaultExtName,
-            prompt : "Please enter a name for the table extension."
-        });
     }
 
     //#endregion

--- a/src/objectbuilders/xmlPortBuilder.ts
+++ b/src/objectbuilders/xmlPortBuilder.ts
@@ -1,8 +1,9 @@
 import * as vscode from 'vscode';
-import { ObjectBuilder } from "./objectBuilder";
-import { ALSymbolInfo } from "../alSymbolInfo";
 import { ALObjectWriter } from './alObjectWriter';
+import { ALSymbolInfo } from "../alSymbolInfo";
 import { ALSymbolKind } from '../alSymbolKind';
+import { FileBuilder } from './fileBuilder';
+import { ObjectBuilder } from "./objectBuilder";
 
 export class XmlPortBuilder extends ObjectBuilder {
 
@@ -13,11 +14,16 @@ export class XmlPortBuilder extends ObjectBuilder {
     //#region Wizards with UI
 
     async showXmlPortWizard(tableSymbol : ALSymbolInfo) {
-        let objectName : string = await this.getXmlPortName(
-            tableSymbol.symbolName.trim() + " XmlPort");
+        const objType : ALSymbolKind = ALSymbolKind.XmlPort;
+
+        let objectId : number = await this.getObjectId("Please enter an ID for the xmlport object.", 0);
+
+        let objectName : string = tableSymbol.symbolName.trim() + " XmlPort";
+        objectName = await this.getObjectName("Please enter a name for the xmlport object.", objectName);
         
-        if (!objectName)
+        if (!objectName) {
             return;
+        }
 
         //ask user to select table field node type
         let fieldAsAttributeText = "Table fields as xml attributes";
@@ -37,17 +43,8 @@ export class XmlPortBuilder extends ObjectBuilder {
         if ((!selectedNodeType) || (!selectedNodeType.label))
             return;
         
-        this.showNewDocument(this.buildXmlPortForTable(tableSymbol, 0, objectName, (selectedNodeType.label == fieldAsElementText)));
-    }
-
-    //#endregion
-
-    //#region UI functions
-
-    private getXmlPortName(defaultName : string) : Thenable<string> {
-        return vscode.window.showInputBox({
-            value : defaultName,
-            prompt : "Please enter new xmlport name"});
+        let fileName : string = FileBuilder.getPatternGeneratedFullObjectFileName(objType, objectId, objectName);
+        this.showNewDocument(this.buildXmlPortForTable(tableSymbol, objectId, objectName, (selectedNodeType.label == fieldAsElementText)), fileName, objType);
     }
 
     //#endregion


### PR DESCRIPTION
Hi @anzwdev,

Here is another pull request, which introduces capabilities for automatic file generation.
That is, if you choose one of the commands such as "New Card Page" or "New Table Extension", it is now possible to have a file for it to be automatically generated.
I think this is a very valuable addition, as (re)naming files in your AL project in VSCode is always kind of a hassle.

![auto_file_gen](https://user-images.githubusercontent.com/7383241/51089303-52d2d880-176b-11e9-8932-6972329feb87.gif)

#### Automatic File Generation
This functionality is triggered when the `alOutline.autoGenerateFiles` setting is **enabled**.
If you create a new object from the object browser or outline, then a file will be generated rather than a new Untitled-# editor being opened.
The name of the file is based on a pattern specified in the `alOutline.fullObjectFileNamePattern` or `alOutline.extensionObjectFileNamePattern` settings, which by default will be configured with the file naming convention that is specified at the [Best Practices for AL Code](https://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/compliance/apptest-bestpracticesforalcode) page.
In addition, I have added a setting, `alOutline.extensionObjectNamePattern`, that allows you to specify a naming pattern for **extension** object names.

#### File Generation Directory
By default the file will be placed in the root directory of your project folder.
You can change the directory to add new files using the `alOutline.autoGenerateFileDirectory` setting, in which you can enter a path relative to the root of your project folder.
Here you can also use the placeholder "\<ObjectType\>"/"\<ObjectTypeShort\>" if you would like to have your objects in a folder per object type.
Also, note that if you are working in a multi-root workspace, then you will be prompted to specify the workspace to create the file in.

#### Settings to Enable/Disable Prompts
I have also added some settings that allow you to enable/disable the prompts for user input for object IDs (`alOutline.promptForObjectId`), object names (`alOutline.promptForObjectName`) *and* output directory (`alOutline.promptForFilePath`). These settings apply to both full and extension objects generated from the object builders.

Finally, I have added an extra setting, `alOutline.stripNonAlphanumericCharactersFromObjectNames`, that also allows one to always have the non-alphanumeric characters to be stripped from new object names. Personally, I do not like to have object names that include characters that need to be escaped, and instead prefer names that only include alpha-numeric characters, so that's why I have added this setting.

Please let me know what you think about this addition, and/or if you have any further comments or suggestions on this pull request.
One thing, I think, might be open for discussion are the default values for these new settings. For example, I have now set the default for `alOutline.autoGenerateFiles` to **true**, which is my personal preference, but may or may not be the most appropriate default value.