### PR TITLE
Cancel object file generation when pressing the "Escape" button from the object ID prompt.

### DIFF
--- a/src/objectbuilders/objectBuilder.ts
+++ b/src/objectbuilders/objectBuilder.ts
@@ -64,12 +64,12 @@ export class ObjectBuilder {
         }
 
         if (!objectIdString) {
-            objectIdString = "0";
+            return -1;
         }
         
         let objectId : number = Number(objectIdString);
         if (isNaN(objectId)) {
-            return 0;
+            return -1;
         }
 
         return objectId;

--- a/src/objectbuilders/pageBuilder.ts
+++ b/src/objectbuilders/pageBuilder.ts
@@ -17,6 +17,9 @@ export class PageBuilder extends ObjectBuilder {
         const objType : ALSymbolKind = ALSymbolKind.Page;
 
         let objectId : number = await this.getObjectId("Please enter an ID for the list page.", 0);
+        if (objectId < 0) {
+            return;
+        }
 
         let objectName : string = tableSymbol.symbolName.trim() + " List";
         objectName = await this.getObjectName("Please enter a name for the list page.", objectName);
@@ -33,6 +36,9 @@ export class PageBuilder extends ObjectBuilder {
         const objType : ALSymbolKind = ALSymbolKind.Page;
 
         let objectId : number = await this.getObjectId("Please enter an ID for the card page.", 0);
+        if (objectId < 0) {
+            return;
+        }
 
         let objectName : string = tableSymbol.symbolName.trim() + " Card";
         objectName = await this.getObjectName("Please enter a name for the card page.", objectName);

--- a/src/objectbuilders/pageExtBuilder.ts
+++ b/src/objectbuilders/pageExtBuilder.ts
@@ -17,6 +17,9 @@ export class PageExtBuilder extends ObjectBuilder {
         const extObjType : ALSymbolKind = ALSymbolKind.PageExtension;
         
         let extObjectId : number = await this.getObjectId("Please enter an ID for the page extension.", 0);
+        if (extObjectId < 0) {
+            return;
+        }
 
         let extObjectName: string = FileBuilder.getPatternGeneratedExtensionObjectName(extObjType, extObjectId, pageSymbol);
         extObjectName = await this.getObjectName("Please enter a name for the page extension.", extObjectName);

--- a/src/objectbuilders/queryBuilder.ts
+++ b/src/objectbuilders/queryBuilder.ts
@@ -17,6 +17,9 @@ export class QueryBuilder extends ObjectBuilder {
         const objType : ALSymbolKind = ALSymbolKind.Query;
 
         let objectId : number = await this.getObjectId("Please enter an ID for the query object.", 0);
+        if (objectId < 0) {
+            return;
+        }
 
         let objectName : string = tableSymbol.symbolName.trim() + " Query";
         objectName = await this.getObjectName("Please enter a name for the query object.", objectName);

--- a/src/objectbuilders/reportBuilder.ts
+++ b/src/objectbuilders/reportBuilder.ts
@@ -17,6 +17,9 @@ export class ReportBuilder extends ObjectBuilder {
         const objType : ALSymbolKind = ALSymbolKind.Report;
 
         let objectId : number = await this.getObjectId("Please enter an ID for the report object.", 0);
+        if (objectId < 0) {
+            return;
+        }
 
         let objectName : string = tableSymbol.symbolName.trim() + " Report";
         objectName = await this.getObjectName("Please enter a name for the report object.", objectName);

--- a/src/objectbuilders/tableExtBuilder.ts
+++ b/src/objectbuilders/tableExtBuilder.ts
@@ -17,6 +17,9 @@ export class TableExtBuilder extends ObjectBuilder {
         const extObjType : ALSymbolKind = ALSymbolKind.TableExtension;
 
         let extObjectId : number = await this.getObjectId("Please enter an ID for the table extension.", 0);
+        if (extObjectId < 0) {
+            return;
+        }
 
         let extObjectName: string = FileBuilder.getPatternGeneratedExtensionObjectName(extObjType, extObjectId, tableSymbol);
         extObjectName = await this.getObjectName("Please enter a name for the table extension.", extObjectName);

--- a/src/objectbuilders/xmlPortBuilder.ts
+++ b/src/objectbuilders/xmlPortBuilder.ts
@@ -17,6 +17,9 @@ export class XmlPortBuilder extends ObjectBuilder {
         const objType : ALSymbolKind = ALSymbolKind.XmlPort;
 
         let objectId : number = await this.getObjectId("Please enter an ID for the xmlport object.", 0);
+        if (objectId < 0) {
+            return;
+        }
 
         let objectName : string = tableSymbol.symbolName.trim() + " XmlPort";
         objectName = await this.getObjectName("Please enter a name for the xmlport object.", objectName);


### PR DESCRIPTION
Hi @anzwdev,

If you start to create a new object, for example from the context menu in the AL Object Browser, then you will be prompted to provide an object ID to use for the new object, i.e.:

![ft8vci3b40](https://user-images.githubusercontent.com/7383241/53685774-77850e80-3d1f-11e9-931b-8470d7d0a96c.png)

However, if you make up your mind, and want to cancel this by pressing the "Escape" button or shifting the focus from the prompt to anything else, then the action still continues (which might lead to the extension still creating the file, depending on your settings), while it would actually be better to completely cancel the action. (After all, the prompt says "Press 'Escape' to cancel." 😉)

With this pull request I have made the change so that when the prompt returns with a value of `undefined` for the object ID, then the complete action for generating the object will be cancelled.

(By the way, I just realized the prompt accepts non-natural numbers as well (such as negative numbers, floating points, etc.), although this is less of an issue)
