### PR TITLE
Multiple Object Generation

### DIFF
--- a/htmlresources/objectbrowser/css/objectbrowser.css
+++ b/htmlresources/objectbrowser/css/objectbrowser.css
@@ -95,13 +95,3 @@
     background-color: #e0e0e0;
     color: #404040;
 }
-
-*.unselectable
-{
-	-webkit-touch-callout: none;
-	  -webkit-user-select: none;
-	   -khtml-user-select: none;
-	     -moz-user-select: none;
-	      -ms-user-select: none;
-	          user-select: none;
-}

--- a/htmlresources/objectbrowser/css/objectbrowser.css
+++ b/htmlresources/objectbrowser/css/objectbrowser.css
@@ -95,3 +95,13 @@
     background-color: #e0e0e0;
     color: #404040;
 }
+
+*.unselectable
+{
+	-webkit-touch-callout: none;
+	  -webkit-user-select: none;
+	   -khtml-user-select: none;
+	     -moz-user-select: none;
+	      -ms-user-select: none;
+	          user-select: none;
+}

--- a/htmlresources/objectbrowser/js/jquery.rowselector.js
+++ b/htmlresources/objectbrowser/js/jquery.rowselector.js
@@ -1,0 +1,95 @@
+// This is a customized version of jquery.rowselector.js:
+// * Disable text selection only while the shift-key is pressed to select multiple rows.
+// * Support the use of the ctrl.-key to select rows one by one.
+
+(function ($)
+{
+	$.fn.selectedrows = function ()
+	{
+		var table = $(this[0]);
+		var match = undefined;
+
+		if ((table.prop('tagName').toUpperCase() === 'TABLE') && (typeof table.attr('data-rs-selectable') !== 'undefined'))
+		{
+			var c = table.attr('data-rs-class') || 'selected';
+			match = $(table).find('tbody tr.' + c);
+		}
+
+		return match;
+	};
+})(jQuery);
+
+
+$(document).ready(function ()
+{
+	var tables = {};
+
+	$('body').on('mouseover', 'table[data-rs-selectable]', function (evt)
+	{
+		// $(this).addClass('unselectable').attr('unselectable', 'on'); //MOD.o
+		//MOD.ns
+		if (evt.shiftKey) {
+			$(this).addClass('unselectable').attr('unselectable', 'on');
+		}
+		else {
+			$(this).removeClass('unselectable').attr('unselectable', 'off');
+		}
+		//MOD.ne
+	});
+
+
+	$('body').on('click', 'table[data-rs-selectable] tr', function (evt)
+	{
+		var $this = $(this);
+		var table = $this.closest('table');
+
+		var t = table.attr('data-rs-type')  || 'many';
+		var c = table.attr('data-rs-class') || 'selected';
+
+		if (t !== 'none')
+		{
+			if (t === 'one')
+			{
+				$(this).siblings().removeClass(c).end().addClass(c);
+			}
+			else
+			{
+				$(this).toggleClass(c);
+
+				if (evt.shiftKey)
+				{
+					var last = tables[table.id] || false;
+					if ((last) && (this !== last) && ($(this).hasClass(c) === $(last).hasClass(c)))
+					{
+						var startat = (this.rowIndex > last.rowIndex) ? last : this;
+						var endat   = (this.rowIndex > last.rowIndex) ? this : last;
+						var do_add  = $(this).hasClass(c);
+
+						var rows = $(startat).nextAll('tr');
+						for (var i = 0, l = rows.length; i < l; i += 1)
+						{
+							if (rows[i] === endat) {break;}
+							if (do_add)
+							{
+								$(rows[i]).addClass(c);
+							}
+							else
+							{
+								$(rows[i]).removeClass(c);
+							}
+						}
+					}
+				}
+				//MOD.ns
+				else if (!evt.ctrlKey)
+				{
+					$(this).siblings().removeClass(c).end().addClass(c);
+				}
+				//MOD.ne
+			}
+		}
+
+		tables[table.id] = this;
+		$(table).trigger("clicked.rs.row");
+	});
+});

--- a/htmlresources/objectbrowser/js/jquery.rowselector.js
+++ b/htmlresources/objectbrowser/js/jquery.rowselector.js
@@ -1,6 +1,9 @@
-// This is a customized version of jquery.rowselector.js:
+// This is a customized/improved version of jquery.rowselector.js:
 // * Disable text selection only while the shift-key is pressed to select multiple rows.
 // * Support the use of the ctrl.-key to select rows one by one.
+// * Unselect multiple rows while holding the shift-key, rather than only the last row.
+// * Unselect all other rows while not using the ctrl./shift-key.
+// * Introduce ctrl+A to select all rows.
 
 (function ($)
 {
@@ -24,19 +27,49 @@ $(document).ready(function ()
 {
 	var tables = {};
 
-	$('body').on('mouseover', 'table[data-rs-selectable]', function (evt)
+	//MOD.os
+	// $('body').on('mouseover', 'table[data-rs-selectable]', function (evt)
+	// {
+	// 	$(this).addClass('unselectable').attr('unselectable', 'on');
+	// });
+	//MOD.oe
+
+	//MOD.ns
+	// Prevent text select from shift + click
+	$('body').on('mousedown', 'table[data-rs-selectable]', function(evt)
 	{
-		// $(this).addClass('unselectable').attr('unselectable', 'on'); //MOD.o
-		//MOD.ns
-		if (evt.shiftKey) {
-			$(this).addClass('unselectable').attr('unselectable', 'on');
+		if (evt.shiftKey || evt.ctrlKey) {
+			evt.preventDefault();
 		}
-		else {
-			$(this).removeClass('unselectable').attr('unselectable', 'off');
-		}
-		//MOD.ne
 	});
 
+	
+	// Select all rows on ctrl + A
+	$('body').on('keydown', 'table[data-rs-selectable] tr', function(evt)
+	{
+		if (!evt.ctrlKey) {
+			return;
+		}
+		
+		if (evt.keyCode !== 65) {
+			return;
+		}
+
+		var $this = $(this);
+		var table = $this.closest('table');
+
+		var t = table.attr('data-rs-type')  || 'many';
+		var c = table.attr('data-rs-class') || 'selected';
+		
+		if (t !== 'none' && t !== 'one') {
+			$(this).addClass(c);
+			$(this).siblings().addClass(c);
+		}
+		
+		tables[table.id] = this;
+		$(table).trigger("clicked.rs.row");
+	});
+	//MOD.ne
 
 	$('body').on('click', 'table[data-rs-selectable] tr', function (evt)
 	{
@@ -59,11 +92,20 @@ $(document).ready(function ()
 				if (evt.shiftKey)
 				{
 					var last = tables[table.id] || false;
-					if ((last) && (this !== last) && ($(this).hasClass(c) === $(last).hasClass(c)))
+					// if ((last) && (this !== last) && ($(this).hasClass(c) === $(last).hasClass(c)))	//MOD.o
+					if ((last) && (this !== last))														//MOD.n
 					{
 						var startat = (this.rowIndex > last.rowIndex) ? last : this;
 						var endat   = (this.rowIndex > last.rowIndex) ? this : last;
 						var do_add  = $(this).hasClass(c);
+						//MOD.ns
+						if (do_add) {
+							$(last).addClass(c);
+						}
+						else {
+							$(last).removeClass(c);
+						}
+						//MOD.ne
 
 						var rows = $(startat).nextAll('tr');
 						for (var i = 0, l = rows.length; i < l; i += 1)

--- a/htmlresources/objectbrowser/js/objectbrowser.js
+++ b/htmlresources/objectbrowser/js/objectbrowser.js
@@ -17,8 +17,8 @@ $(function() {
 });
 
 var dataMode = '';
-var selType = '';
-var selId = 0;
+var pivotType = '';
+var pivotId = 0;
 var objdata = {};
 
 var filterType = [];
@@ -187,7 +187,7 @@ function setMode(newMode, reload) {
 
 function renderData() {
     $('#objects').html(Handlebars.templates.objectlist(objdata));
-    $("tr[data-objt='" + selType + "'][data-objid='" + selId + "']").attr('class', 'objsel');
+    $("tr[data-objt='" + pivotType + "'][data-objid='" + pivotId + "']").attr('class', 'objsel');
 
     initContextMenus();
 }
@@ -284,6 +284,7 @@ function execObjCommand(objtype, objid, cmdname) {
             command : 'execObjCommand',
             objtype : objtype,
             objid : objid,
+            selobjids: getSelectedObjectIds(objtype),
             cmdname : cmdname});
     }
 }
@@ -303,18 +304,48 @@ function execFilterCommand(headColumn, cmdname) {
     }
 }
 
+function updatePivotObject(objtype, objid) {
+    if (vscodeContext) {
+        vscodeContext.postMessage({
+            command : "updatePivotObj",
+            objtype : objtype,
+            objid   : objid
+        });
+    }
+}
+
+function getSelectedObjectIds(objtype) {
+    var selectedIds = [];
+    $('#objlisttab').selectedrows().each(function (idx, selectedrow)
+    {
+        if (selectedrow.dataset.objt === objtype) {
+            selectedIds.push(selectedrow.dataset.objid);
+        }
+    });
+    return selectedIds;
+}
+
 function selectObject(newSelType, newSelId) {
-    if ((newSelType != selType) || (newSelId != selId)) {
-        // //update view
-        // $("tr[data-objt='" + selType + "'][data-objid='" + selId + "']").attr('class', '');
-        // selType = newSelType;
-        // selId = newSelId;
-        // $("tr[data-objt='" + selType + "'][data-objid='" + selId + "']").attr('class', 'objsel');
-        // //notify vscode extension
-        // execObjCommand(selType, selId, "selected");
+    if ((newSelType != pivotType) || (newSelId != pivotId)) {
+        // update view
+        pivotType = newSelType;
+        pivotId = newSelId;
+        // notify vscode extension (to view the corresponding outline)
+        updatePivotObject(pivotType, pivotId);
     }
 }
 
 function objclick(item) {
     selectObject(item.dataset.objt, item.dataset.objid);
 }
+
+$(document).keydown(function(evt)
+{
+    // Disable text-select from ctrl+A.
+	if (evt.ctrlKey) {          
+		if (evt.keyCode == 65) {                         
+			evt.preventDefault();
+			return false;
+		}            
+	}
+});

--- a/htmlresources/objectbrowser/js/objectbrowser.js
+++ b/htmlresources/objectbrowser/js/objectbrowser.js
@@ -305,13 +305,13 @@ function execFilterCommand(headColumn, cmdname) {
 
 function selectObject(newSelType, newSelId) {
     if ((newSelType != selType) || (newSelId != selId)) {
-        //update view
-        $("tr[data-objt='" + selType + "'][data-objid='" + selId + "']").attr('class', '');
-        selType = newSelType;
-        selId = newSelId;
-        $("tr[data-objt='" + selType + "'][data-objid='" + selId + "']").attr('class', 'objsel');
-        //notify vscode extension
-        execObjCommand(selType, selId, "selected");
+        // //update view
+        // $("tr[data-objt='" + selType + "'][data-objid='" + selId + "']").attr('class', '');
+        // selType = newSelType;
+        // selId = newSelId;
+        // $("tr[data-objt='" + selType + "'][data-objid='" + selId + "']").attr('class', 'objsel');
+        // //notify vscode extension
+        // execObjCommand(selType, selId, "selected");
     }
 }
 

--- a/htmlresources/objectbrowser/js/objectlist.handlebars
+++ b/htmlresources/objectbrowser/js/objectlist.handlebars
@@ -5,7 +5,7 @@
         {{#if visible}}
             {{#each objects}}
                 {{#if objvisible}}
-                    <tr class="objrow" data-objt="{{../objectType}}" data-objid="{{Id}}" data-objname="{{Name}}" onclick="objclick(this)"><td>{{../objectType}}</td><td>{{OId}}</td><td>{{Name}}</td></tr>
+                    <tr class="objrow" data-objt="{{../objectType}}" data-objid="{{Id}}" data-objname="{{Name}}" onclick="objclick(this)" tabindex="0"><td>{{../objectType}}</td><td>{{OId}}</td><td>{{Name}}</td></tr>
                 {{/if}}
             {{/each}}
         {{/if}}

--- a/htmlresources/objectbrowser/js/objectlist.handlebars
+++ b/htmlresources/objectbrowser/js/objectlist.handlebars
@@ -1,4 +1,4 @@
-<table id="objlisttab">
+<table id="objlisttab" data-rs-selectable data-rs-class="objsel">
     <tr id="objhead" class="objhead"><th>Type</th><th>ID</th><th>Name</th></tr>
 
     {{#each objectCollections}}

--- a/htmlresources/objectbrowser/js/objectlist.handlebars.js
+++ b/htmlresources/objectbrowser/js/objectlist.handlebars.js
@@ -31,7 +31,7 @@ templates['objectlist'] = template({"1":function(container,depth0,helpers,partia
 },"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
-  return "<table id=\"objlisttab\">\r\n    <tr id=\"objhead\" class=\"objhead\"><th>Type</th><th>ID</th><th>Name</th></tr>\r\n\r\n"
+  return "<table id=\"objlisttab\" data-rs-selectable data-rs-class=\"objsel\">\r\n    <tr id=\"objhead\" class=\"objhead\"><th>Type</th><th>ID</th><th>Name</th></tr>\r\n\r\n"
     + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.objectCollections : depth0),{"name":"each","hash":{},"fn":container.program(1, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\r\n</table>\r\n";
 },"useData":true,"useDepths":true});

--- a/htmlresources/objectbrowser/js/objectlist.handlebars.js
+++ b/htmlresources/objectbrowser/js/objectlist.handlebars.js
@@ -21,7 +21,7 @@ templates['objectlist'] = template({"1":function(container,depth0,helpers,partia
     + alias2(((helper = (helper = helpers.Id || (depth0 != null ? depth0.Id : depth0)) != null ? helper : alias4),(typeof helper === alias5 ? helper.call(alias3,{"name":"Id","hash":{},"data":data}) : helper)))
     + "\" data-objname=\""
     + alias2(((helper = (helper = helpers.Name || (depth0 != null ? depth0.Name : depth0)) != null ? helper : alias4),(typeof helper === alias5 ? helper.call(alias3,{"name":"Name","hash":{},"data":data}) : helper)))
-    + "\" onclick=\"objclick(this)\"><td>"
+    + "\" onclick=\"objclick(this)\" tabindex=\"0\"><td>"
     + alias2(alias1((depths[1] != null ? depths[1].objectType : depths[1]), depth0))
     + "</td><td>"
     + alias2(((helper = (helper = helpers.OId || (depth0 != null ? depth0.OId : depth0)) != null ? helper : alias4),(typeof helper === alias5 ? helper.call(alias3,{"name":"OId","hash":{},"data":data}) : helper)))

--- a/htmlresources/objectbrowser/objectbrowser.html
+++ b/htmlresources/objectbrowser/objectbrowser.html
@@ -5,6 +5,7 @@
         <script src="##PATH##/htmlresources/objectbrowser/js/jquery.min.js"></script>
         <script src="##PATH##/htmlresources/objectbrowser/js/jquery.ui.position.min.js"></script>
         <script src="##PATH##/htmlresources/objectbrowser/js/jquery.contextmenu.min.js"></script>
+        <script src="##PATH##/htmlresources/objectbrowser/js/jquery.rowselector.js"></script>
         <script src="##PATH##/htmlresources/objectbrowser/js/objectlist.handlebars.js"></script>
         <script src="##PATH##/htmlresources/objectbrowser/js/objectbrowser.js"></script>
         <link rel="stylesheet" type="text/css" href="##PATH##/htmlresources/objectbrowser/css/jquery.contextMenu.min.css">

--- a/src/alappviewer/alAppFileViewer.ts
+++ b/src/alappviewer/alAppFileViewer.ts
@@ -106,6 +106,13 @@ export class ALAppFileViewer {
     protected async appFileObjCommand(objType : string, objId : number, selObjIds: number[], commandName : string) {
         var multipleObjects = (selObjIds.length > 1) && (commandName !== 'runinwebclient');
         if (multipleObjects) {
+            if (selObjIds.length > 100) {
+                let action: string = await vscode.window.showWarningMessage(`You are about to run this command for ${selObjIds.length} objects. Do you want to continue?`, {modal: true}, 'Yes', 'No');
+                if (action !== 'Yes') {
+                    return;
+                }
+            }
+
             var symbolInfoList = this.objectLibraries.findALSymbolInfoList(objType, selObjIds);
             if (symbolInfoList) {
                 if (commandName === 'newcardpage')

--- a/src/alappviewer/alAppFileViewer.ts
+++ b/src/alappviewer/alAppFileViewer.ts
@@ -87,8 +87,11 @@ export class ALAppFileViewer {
                 else if (m.command == "errorInFilter") {
                     vscode.window.showErrorMessage('Invalid filter: ' + m.message);
                 }
-                else {
-                    this.appFileObjCommand(m.objtype, m.objid, m.cmdname);
+                else if (m.command == "updatePivotObj") {
+                    this.updatePivotObjCommand(m.objtype, m.objid);
+                }
+                else if (m.command == "execObjCommand") {
+                    this.appFileObjCommand(m.objtype, m.objid, m.selobjids, m.cmdname);
                 }
             }                
         }, null, this.disposables);
@@ -100,13 +103,10 @@ export class ALAppFileViewer {
             this.panel.webview.html = this.htmlContent;
     }    
 
-    protected async appFileObjCommand(objType : string, objId : number, commandName : string) {
-        var symbolInfo = this.objectLibraries.findALSymbolInfo(objType, objId);
+    protected async appFileObjCommand(objType : string, objId : number, selObjIds: number[], commandName : string) {
+        var symbolInfo = this.objectLibraries.findALSymbolInfo(objType, objId); //TODO: Generate multiple objects, if multiple are selected.
         if (symbolInfo) {
-            if ((commandName === 'selected') && (this.codeOutlineProvider)) {
-                this.codeOutlineProvider.setAppALSymbolInfo(symbolInfo);
-            }
-            else if (commandName === 'newcardpage')
+            if (commandName === 'newcardpage')
                 await this.objectBuilders.pageBuilder.showCardPageWizard(symbolInfo);
             else if (commandName === 'newlistpage')
                 await this.objectBuilders.pageBuilder.showListPageWizard(symbolInfo);
@@ -123,6 +123,13 @@ export class ALAppFileViewer {
             else if (commandName === 'extendpage')
                 await this.objectBuilders.pageExtBuilder.showPageExtWizard(symbolInfo);
         }            
+    }
+
+    protected async updatePivotObjCommand(objType: string, objId: number) {
+        var symbolInfo = this.objectLibraries.findALSymbolInfo(objType, objId);
+        if (symbolInfo && this.codeOutlineProvider) {
+            this.codeOutlineProvider.setAppALSymbolInfo(symbolInfo);
+        }
     }
 
     //#region Filter View

--- a/src/alappviewer/alAppFileViewer.ts
+++ b/src/alappviewer/alAppFileViewer.ts
@@ -104,25 +104,47 @@ export class ALAppFileViewer {
     }    
 
     protected async appFileObjCommand(objType : string, objId : number, selObjIds: number[], commandName : string) {
-        var symbolInfo = this.objectLibraries.findALSymbolInfo(objType, objId); //TODO: Generate multiple objects, if multiple are selected.
-        if (symbolInfo) {
-            if (commandName === 'newcardpage')
-                await this.objectBuilders.pageBuilder.showCardPageWizard(symbolInfo);
-            else if (commandName === 'newlistpage')
-                await this.objectBuilders.pageBuilder.showListPageWizard(symbolInfo);
-            else if (commandName === 'newreport')
-                await this.objectBuilders.reportBuilder.showReportWizard(symbolInfo);
-            else if (commandName === 'newxmlport')
-                await this.objectBuilders.xmlPortBuilder.showXmlPortWizard(symbolInfo);
-            else if (commandName === 'newquery')
-                await this.objectBuilders.queryBuilder.showQueryWizard(symbolInfo);
-            else if (commandName === 'runinwebclient')
-                this.alObjectRunner.runInWebClient(symbolInfo);
-            else if (commandName === 'extendtable')
-                await this.objectBuilders.tableExtBuilder.showTableExtWizard(symbolInfo);
-            else if (commandName === 'extendpage')
-                await this.objectBuilders.pageExtBuilder.showPageExtWizard(symbolInfo);
-        }            
+        var multipleObjects = (selObjIds.length > 1) && (commandName !== 'runinwebclient');
+        if (multipleObjects) {
+            var symbolInfoList = this.objectLibraries.findALSymbolInfoList(objType, selObjIds);
+            if (symbolInfoList) {
+                if (commandName === 'newcardpage')
+                    await this.objectBuilders.pageBuilder.showMultiPageWizard(symbolInfoList, 'Card');
+                else if (commandName === 'newlistpage')
+                    await this.objectBuilders.pageBuilder.showMultiPageWizard(symbolInfoList, 'List');
+                else if (commandName === 'newreport')
+                    await this.objectBuilders.reportBuilder.showMultiReportWizard(symbolInfoList);
+                else if (commandName === 'newxmlport')
+                    await this.objectBuilders.xmlPortBuilder.showMultiXmlPortWizard(symbolInfoList);
+                else if (commandName === 'newquery')
+                    await this.objectBuilders.queryBuilder.showMultiQueryWizard(symbolInfoList);
+                else if (commandName === 'extendtable')
+                    await this.objectBuilders.tableExtBuilder.showMultiTableExtWizard(symbolInfoList);
+                else if (commandName === 'extendpage')
+                    await this.objectBuilders.pageExtBuilder.showMultiPageExtWizard(symbolInfoList);
+            }
+        }
+        else {
+            var symbolInfo = this.objectLibraries.findALSymbolInfo(objType, objId);
+            if (symbolInfo) {
+                if (commandName === 'newcardpage')
+                    await this.objectBuilders.pageBuilder.showPageWizard(symbolInfo, 'Card');
+                else if (commandName === 'newlistpage')
+                    await this.objectBuilders.pageBuilder.showPageWizard(symbolInfo, 'List');
+                else if (commandName === 'newreport')
+                    await this.objectBuilders.reportBuilder.showReportWizard(symbolInfo);
+                else if (commandName === 'newxmlport')
+                    await this.objectBuilders.xmlPortBuilder.showXmlPortWizard(symbolInfo);
+                else if (commandName === 'newquery')
+                    await this.objectBuilders.queryBuilder.showQueryWizard(symbolInfo);
+                else if (commandName === 'runinwebclient')
+                    this.alObjectRunner.runInWebClient(symbolInfo);
+                else if (commandName === 'extendtable')
+                    await this.objectBuilders.tableExtBuilder.showTableExtWizard(symbolInfo);
+                else if (commandName === 'extendpage')
+                    await this.objectBuilders.pageExtBuilder.showPageExtWizard(symbolInfo);
+            }   
+        }         
     }
 
     protected async updatePivotObjCommand(objType: string, objId: number) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,11 +30,11 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         vscode.commands.registerCommand(
         'alOutline.createCardPage', 
-        offset => objectBuildersCollection.pageBuilder.showCardPageWizard(offset)));
+        offset => objectBuildersCollection.pageBuilder.showPageWizard(offset, 'Card')));
     context.subscriptions.push(
         vscode.commands.registerCommand(
             'alOutline.createListPage', 
-            offset => objectBuildersCollection.pageBuilder.showListPageWizard(offset)));
+            offset => objectBuildersCollection.pageBuilder.showPageWizard(offset, 'Page')));
     context.subscriptions.push(
         vscode.commands.registerCommand(
             'alOutline.createReport', 

--- a/src/objectbuilders/fileBuilder.ts
+++ b/src/objectbuilders/fileBuilder.ts
@@ -97,27 +97,45 @@ export class FileBuilder {
         return '';
     }
 
-    public static getPromptForFileName() : boolean {
-        let value : boolean = vscode.workspace.getConfiguration('alOutline').get('promptForFilePath');
-        return value;
+    public static getAutoGenerateFiles() : boolean {
+        return vscode.workspace.getConfiguration('alOutline').get('autoGenerateFiles');
+    }
+
+    public static getPromptForObjectName() : boolean {
+        return vscode.workspace.getConfiguration('alOutline').get('promptForObjectName');
     }
 
     public static checkCrsFileNamePatternRequired() : boolean {
-        if ((!FileBuilder.getPromptForFileName()) && (!FileBuilder.hasCrsFileNamePattern())) {
-            vscode.window.showErrorMessage('File name pattern for new objects has not been specified in CRS.FileNamePattern setting. Please go to Visual Studio Code settings and update it or enable file path prompt by switching alOutline.promptForFilePath setting to true.');
+        // If files are automatically generated AND no file naming pattern is available, then give an error that the file name pattern setting needs to be added.
+        if (FileBuilder.getAutoGenerateFiles() && !FileBuilder.hasCrsFileNamePattern()) {
+            vscode.window.showErrorMessage('File name pattern for new objects has not been specified in the "CRS.FileNamePattern" setting. Please add this setting to your VS Code workspace or user settings.');
             return false;
         }
         return true;
     }
 
     public static checkCrsExtensionFileNamePatternRequired() : boolean {
-        if ((!FileBuilder.getPromptForFileName()) && (!FileBuilder.hasCrsExtensionFileNamePattern())) {
-            vscode.window.showErrorMessage('File name pattern for extension objects has not been specified in CRS.FileNamePatternExtensions setting. Please go to Visual Studio Code settings and update it or enable file path prompt by switching alOutline.promptForFilePath setting to true.');
+        // If files are automatically generated AND no extension file naming pattern is available, then give an error that the extension file name pattern setting needs to be added.
+        if (FileBuilder.getAutoGenerateFiles() && !FileBuilder.hasCrsExtensionFileNamePattern()) {
+            vscode.window.showErrorMessage('File name pattern for extension objects has not been specified in the "CRS.FileNamePatternExtensions" setting. Please add this setting to your VS Code workspace or user settings.');
             return false;
         }
         return true;
     }
 
+    public static checkCrsExtensionObjectNamePatternRequired(multipleObjects: boolean) : boolean {
+        // When multiple objects are generated, a prompt for the extension object name is not shown, so we need a pattern -> if not available, then this setting needs to be set first.
+        if (multipleObjects && !FileBuilder.hasCrsExtensionObjectNamePattern()) {
+            vscode.window.showErrorMessage('Extension object name pattern has not been specified in the "CRS.ExtensionObjectNamePattern" setting. Please add this setting to your VS Code workspace or user settings.');
+            return false;
+        }
+        // When a single object is generated, the name can either come from a pattern or from the user via a prompt -> if both are unavailable/disabled, then either of these settings need to be added/enabled.
+        else if (!multipleObjects && !FileBuilder.hasCrsExtensionObjectNamePattern() && !FileBuilder.getPromptForObjectName()) {
+            vscode.window.showErrorMessage('The "CRS.ExtensionObjectNamePattern" setting is undefined and the "alOutline.promptForObjectName" setting is disabled. Please update your VS Code workspace or user settings.');
+            return false;
+        }
+        return true;
+    }
 
     public static hasCrsFileNamePattern() : boolean {
         let patternText = vscode.workspace.getConfiguration('CRS', null).get('FileNamePattern');

--- a/src/objectbuilders/fileBuilder.ts
+++ b/src/objectbuilders/fileBuilder.ts
@@ -7,7 +7,7 @@ import { CRSALLangExtHelper } from '../crsAlLangExtHelper';
 import { ObjectBuilder } from './objectBuilder';
 
 export class FileBuilder {
-    public static async generateObjectFile(content: string, fileName: string, objectType: ALSymbolKind): Promise<string | undefined> {
+    public static async generateObjectFile(content: string, fileName: string, relativeFileDir: string): Promise<string | undefined> {
         // Determine the project root directory.
         let workspaceFolderCount: number = vscode.workspace.workspaceFolders.length;
         if (workspaceFolderCount < 1) {
@@ -27,17 +27,6 @@ export class FileBuilder {
 
         // Determine the directory to place the files in; create the directory if it does not exist yet.
         const baseFileDir : string = workspaceFolder.uri.fsPath;
-        let relativeFileDir : string = await this.getPatternGeneratedRelativeFilePath(objectType);
-
-        const promptForFilePath: boolean = vscode.workspace.getConfiguration('alOutline').get('promptForFilePath');
-        if (promptForFilePath) {
-            relativeFileDir = await vscode.window.showInputBox({
-                value  : relativeFileDir,
-                prompt : 'Please specify a directory, relative to the root, to create the new file in.',
-                ignoreFocusOut: true
-            });
-        }
-        
         const newFileDirectory : string = path.join(baseFileDir, relativeFileDir);
 
         if (relativeFileDir) {
@@ -176,7 +165,7 @@ export class FileBuilder {
         return extensionObjectName + '.al';
     }
 
-    private static async getPatternGeneratedRelativeFilePath(objectType: ALSymbolKind) : Promise<string> {       
+    public static async getPatternGeneratedRelativeFilePath(objectType: ALSymbolKind) : Promise<string> {       
         let typeName = this.getObjectTypeFromSymbolInfo(objectType);
         let shortTypeName : string = '';                
         let output: string = vscode.workspace.getConfiguration('alOutline').get('autoGenerateFileDirectory');

--- a/src/objectbuilders/objectBuilder.ts
+++ b/src/objectbuilders/objectBuilder.ts
@@ -7,18 +7,18 @@ export class ObjectBuilder {
     constructor() {
     }
 
-    protected showNewDocument(content : string, fileName?: string, objectType?: ALSymbolKind) {
+    protected showNewDocument(content : string, fileName?: string, relativeFileDir?: string) {
         let autoGenerateFile: boolean = this.shouldAutoGenerateFiles();
         if (autoGenerateFile && fileName) {
-            this.showNewGeneratedFile(content, fileName, objectType);
+            this.showNewGeneratedFile(content, fileName, relativeFileDir);
         }
         else {
             this.showNewUntitledDocument(content);
         }
     }
 
-    private showNewGeneratedFile(content : string, fileName : string, objectType : ALSymbolKind) {
-        FileBuilder.generateObjectFile(content, fileName, objectType).then(
+    private showNewGeneratedFile(content : string, fileName : string, relativeFileDir: string) {
+        FileBuilder.generateObjectFile(content, fileName, relativeFileDir).then(
             path => {
                 if (path) {
                     vscode.workspace.openTextDocument(path).then(
@@ -92,6 +92,14 @@ export class ObjectBuilder {
         return objectName;
     }
 
+    protected async getRelativeFileDir(objectType : ALSymbolKind) : Promise<string | undefined> {
+        let relativeFileDir : string = await FileBuilder.getPatternGeneratedRelativeFilePath(objectType);
+        if (this.shouldPromptForFileDir() && this.shouldAutoGenerateFiles()) {
+            relativeFileDir = await this.promptForFileDir('Please specify a directory, relative to the root, to create the new file(s) in.', relativeFileDir);
+        }
+        return relativeFileDir;
+    }
+
     //#region UI functions
 
     private promptForObjectId(promptText: string, defaultObjectId : string) : Thenable<string | undefined> {
@@ -117,6 +125,14 @@ export class ObjectBuilder {
         });
     }
 
+    private promptForFileDir(promptText: string, defaultFilePath: string) : Thenable<string | undefined> {
+        return vscode.window.showInputBox({
+            value  : defaultFilePath,
+            prompt : promptText,
+            ignoreFocusOut: true
+        });
+    }
+
     //#endregion
 
     //#region Setting Helper Functions
@@ -127,6 +143,10 @@ export class ObjectBuilder {
 
     private shouldPromptForObjectName() : boolean {
         return vscode.workspace.getConfiguration('alOutline').get('promptForObjectName');
+    }
+
+    private shouldPromptForFileDir() : boolean {
+        return vscode.workspace.getConfiguration('alOutline').get('promptForFilePath');
     }
 
     private shouldStripCharacters() : boolean {

--- a/src/objectbuilders/pageBuilder.ts
+++ b/src/objectbuilders/pageBuilder.ts
@@ -32,7 +32,8 @@ export class PageBuilder extends ObjectBuilder {
         }
 
         let fileName : string = await FileBuilder.getPatternGeneratedFullObjectFileName(objType, objectId, objectName);
-        this.showNewDocument(this.buildListPageForTable(tableSymbol, objectId, objectName), fileName, objType);
+        let relativeFileDir: string = await this.getRelativeFileDir(objType);
+        this.showNewDocument(this.buildListPageForTable(tableSymbol, objectId, objectName), fileName, relativeFileDir);
     }
 
     async showCardPageWizard(tableSymbol : ALSymbolInfo) {
@@ -54,7 +55,8 @@ export class PageBuilder extends ObjectBuilder {
         }
 
         let fileName : string = await FileBuilder.getPatternGeneratedFullObjectFileName(objType, objectId, objectName);
-        this.showNewDocument(this.buildCardPageForTable(tableSymbol, objectId, objectName), fileName, objType);
+        let relativeFileDir: string = await this.getRelativeFileDir(objType);
+        this.showNewDocument(this.buildCardPageForTable(tableSymbol, objectId, objectName), fileName, relativeFileDir);
     }
 
     //#endregion

--- a/src/objectbuilders/pageBuilder.ts
+++ b/src/objectbuilders/pageBuilder.ts
@@ -13,50 +13,65 @@ export class PageBuilder extends ObjectBuilder {
 
     //#region Wizards with UI
 
-    async showListPageWizard(tableSymbol : ALSymbolInfo) {
-        if (!FileBuilder.checkCrsFileNamePatternRequired())
+    async showMultiPageWizard(tableSymbols: ALSymbolInfo[], pageType: string) {
+        if (!FileBuilder.checkCrsExtensionFileNamePatternRequired())
             return;
 
         const objType : ALSymbolKind = ALSymbolKind.Page;
 
-        let objectId : number = await this.getObjectId("Please enter an ID for the list page.", 0);
-        if (objectId < 0) {
+        let startObjectId: number = await this.getObjectId(`Please enter a starting ID for the ${pageType} pages.`, 0);
+        if (startObjectId < 0) {
             return;
         }
 
-        let objectName : string = tableSymbol.symbolName.trim() + " List";
-        objectName = await this.getObjectName("Please enter a name for the list page.", objectName);
-        
-        if (!objectName) {
-            return;
-        }
-
-        let fileName : string = await FileBuilder.getPatternGeneratedFullObjectFileName(objType, objectId, objectName);
         let relativeFileDir: string = await this.getRelativeFileDir(objType);
-        this.showNewDocument(this.buildListPageForTable(tableSymbol, objectId, objectName), fileName, relativeFileDir);
+
+        for (let i = 0; i < tableSymbols.length; i++) {
+            let tableSymbol = tableSymbols[i];
+            let objectId: number = startObjectId + i;
+            let objectName : string = this.getDefaultPageName(tableSymbol, pageType);
+
+            await this.createAndShowNewPage(tableSymbol, objType, objectId, objectName, pageType, relativeFileDir);
+        }
     }
 
-    async showCardPageWizard(tableSymbol : ALSymbolInfo) {
+    async showPageWizard(tableSymbol : ALSymbolInfo, pageType: string) {
         if (!FileBuilder.checkCrsFileNamePatternRequired())
             return;
-            
+
         const objType : ALSymbolKind = ALSymbolKind.Page;
 
-        let objectId : number = await this.getObjectId("Please enter an ID for the card page.", 0);
+        let objectId : number = await this.getObjectId(`Please enter an ID for the ${pageType} page.`, 0);
         if (objectId < 0) {
             return;
         }
 
-        let objectName : string = tableSymbol.symbolName.trim() + " Card";
-        objectName = await this.getObjectName("Please enter a name for the card page.", objectName);
+        let objectName : string = this.getDefaultPageName(tableSymbol, pageType);
+        objectName = await this.getObjectName(`Please enter a name for the ${pageType} page.`, objectName);
         
         if (!objectName) {
             return;
         }
 
-        let fileName : string = await FileBuilder.getPatternGeneratedFullObjectFileName(objType, objectId, objectName);
         let relativeFileDir: string = await this.getRelativeFileDir(objType);
-        this.showNewDocument(this.buildCardPageForTable(tableSymbol, objectId, objectName), fileName, relativeFileDir);
+        await this.createAndShowNewPage(tableSymbol, objType, objectId, objectName, pageType, relativeFileDir);
+    }
+
+    private async createAndShowNewPage(tableSymbol: ALSymbolInfo, objType: ALSymbolKind, objectId: number, objectName: string, pageType: string, relativeFileDir: string) {
+        let fileName : string = await FileBuilder.getPatternGeneratedFullObjectFileName(objType, objectId, objectName);
+        let pageContents: string;
+        if (pageType === 'List') {
+            pageContents = this.buildListPageForTable(tableSymbol, objectId, objectName);
+        }
+        else if (pageType === 'Card') {
+            pageContents = this.buildCardPageForTable(tableSymbol, objectId, objectName);
+        }
+        else {
+            vscode.window.showErrorMessage(`Page generator for page type: ${pageType} not implemented.`)
+            return;
+        }
+
+        this.showNewDocument(pageContents, fileName, relativeFileDir);
     }
 
     //#endregion
@@ -124,4 +139,11 @@ export class PageBuilder extends ObjectBuilder {
 
     //#endregion
 
+    //#region Helper Methods
+
+    private getDefaultPageName(tableSymbol: ALSymbolInfo, pageType: string) : string {
+        return `${tableSymbol.symbolName.trim()} ${pageType}`;
+    }
+    
+    //#endregion
 }

--- a/src/objectbuilders/pageExtBuilder.ts
+++ b/src/objectbuilders/pageExtBuilder.ts
@@ -15,7 +15,7 @@ export class PageExtBuilder extends ObjectBuilder {
     //#region Wizards with UI
 
     async showMultiPageExtWizard(pageSymbols: ALSymbolInfo[]) {
-        if (!FileBuilder.checkCrsExtensionFileNamePatternRequired())
+        if (!FileBuilder.checkCrsExtensionFileNamePatternRequired() || !FileBuilder.checkCrsExtensionObjectNamePatternRequired(true))
             return;
 
         const extObjType : ALSymbolKind = ALSymbolKind.PageExtension;
@@ -37,7 +37,7 @@ export class PageExtBuilder extends ObjectBuilder {
     }
 
     async showPageExtWizard(pageSymbol : ALSymbolInfo) {
-        if (!FileBuilder.checkCrsExtensionFileNamePatternRequired())
+        if (!FileBuilder.checkCrsExtensionFileNamePatternRequired() || !FileBuilder.checkCrsExtensionObjectNamePatternRequired(false))
             return;
 
         const extObjType : ALSymbolKind = ALSymbolKind.PageExtension;

--- a/src/objectbuilders/pageExtBuilder.ts
+++ b/src/objectbuilders/pageExtBuilder.ts
@@ -14,6 +14,28 @@ export class PageExtBuilder extends ObjectBuilder {
 
     //#region Wizards with UI
 
+    async showMultiPageExtWizard(pageSymbols: ALSymbolInfo[]) {
+        if (!FileBuilder.checkCrsExtensionFileNamePatternRequired())
+            return;
+
+        const extObjType : ALSymbolKind = ALSymbolKind.PageExtension;
+
+        let startObjectId: number = await this.getObjectId("Please enter a starting ID for the page extensions.", 0);
+        if (startObjectId < 0) {
+            return;
+        }
+
+        let relativeFileDir: string = await this.getRelativeFileDir(extObjType);
+
+        for (let i = 0; i < pageSymbols.length; i++) {
+            let pageSymbol = pageSymbols[i];
+            let extObjectId: number = startObjectId + i;
+            let extObjectName: string = await FileBuilder.getPatternGeneratedExtensionObjectName(extObjType, extObjectId, pageSymbol);
+
+            await this.createAndShowNewPageExtension(pageSymbol, extObjType, extObjectId, extObjectName, relativeFileDir);
+        }
+    }
+
     async showPageExtWizard(pageSymbol : ALSymbolInfo) {
         if (!FileBuilder.checkCrsExtensionFileNamePatternRequired())
             return;
@@ -31,8 +53,12 @@ export class PageExtBuilder extends ObjectBuilder {
             return;
         }
 
-        let fileName : string = await FileBuilder.getPatternGeneratedExtensionObjectFileName(extObjType, extObjectId, extObjectName, pageSymbol);
         let relativeFileDir: string = await this.getRelativeFileDir(extObjType);
+        await this.createAndShowNewPageExtension(pageSymbol, extObjType, extObjectId, extObjectName, relativeFileDir);
+    }
+
+    private async createAndShowNewPageExtension(pageSymbol: ALSymbolInfo, extObjType: ALSymbolKind, extObjectId: number, extObjectName: string, relativeFileDir: string) {
+        let fileName : string = await FileBuilder.getPatternGeneratedExtensionObjectFileName(extObjType, extObjectId, extObjectName, pageSymbol);
         this.showNewDocument(this.buildPageExtForPage(pageSymbol, extObjectId, extObjectName), fileName, relativeFileDir);
     }
 

--- a/src/objectbuilders/pageExtBuilder.ts
+++ b/src/objectbuilders/pageExtBuilder.ts
@@ -4,6 +4,7 @@ import { ALSymbolInfo } from "../alSymbolInfo";
 import { ALSymbolKind } from '../alSymbolKind';
 import { FileBuilder } from './fileBuilder';
 import { ObjectBuilder } from './objectBuilder';
+import { relative } from 'path';
 
 export class PageExtBuilder extends ObjectBuilder {
 
@@ -31,7 +32,8 @@ export class PageExtBuilder extends ObjectBuilder {
         }
 
         let fileName : string = await FileBuilder.getPatternGeneratedExtensionObjectFileName(extObjType, extObjectId, extObjectName, pageSymbol);
-        this.showNewDocument(this.buildPageExtForPage(pageSymbol, extObjectId, extObjectName), fileName, extObjType);
+        let relativeFileDir: string = await this.getRelativeFileDir(extObjType);
+        this.showNewDocument(this.buildPageExtForPage(pageSymbol, extObjectId, extObjectName), fileName, relativeFileDir);
     }
 
     //#endregion

--- a/src/objectbuilders/queryBuilder.ts
+++ b/src/objectbuilders/queryBuilder.ts
@@ -13,6 +13,28 @@ export class QueryBuilder extends ObjectBuilder {
 
     //#region Wizards with UI
 
+    async showMultiQueryWizard(tableSymbols: ALSymbolInfo[]) {
+        if (!FileBuilder.checkCrsExtensionFileNamePatternRequired())
+            return;
+
+        const objType : ALSymbolKind = ALSymbolKind.Query;
+
+        let startObjectId: number = await this.getObjectId(`Please enter a starting ID for the query objects.`, 0);
+        if (startObjectId < 0) {
+            return;
+        }
+
+        let relativeFileDir: string = await this.getRelativeFileDir(objType);
+
+        for (let i = 0; i < tableSymbols.length; i++) {
+            let tableSymbol = tableSymbols[i];
+            let objectId: number = startObjectId + i;
+            let objectName : string = this.getDefaultQueryName(tableSymbol);
+
+            await this.createAndShowNewQuery(tableSymbol, objType, objectId, objectName, relativeFileDir);
+        }
+    }
+
     async showQueryWizard(tableSymbol : ALSymbolInfo) {
         if (!FileBuilder.checkCrsFileNamePatternRequired())
             return;
@@ -24,15 +46,19 @@ export class QueryBuilder extends ObjectBuilder {
             return;
         }
 
-        let objectName : string = tableSymbol.symbolName.trim() + " Query";
+        let objectName : string = this.getDefaultQueryName(tableSymbol);
         objectName = await this.getObjectName("Please enter a name for the query object.", objectName);
         
         if (!objectName) {
             return;
         }
 
-        let fileName : string = await FileBuilder.getPatternGeneratedFullObjectFileName(objType, objectId, objectName);
         let relativeFileDir: string = await this.getRelativeFileDir(objType);
+        await this.createAndShowNewQuery(tableSymbol, objType, objectId, objectName, relativeFileDir);
+    }
+
+    private async createAndShowNewQuery(tableSymbol: ALSymbolInfo, objType: ALSymbolKind, objectId: number, objectName: string, relativeFileDir: string) {
+        let fileName : string = await FileBuilder.getPatternGeneratedFullObjectFileName(objType, objectId, objectName);
         this.showNewDocument(this.buildQueryForTable(tableSymbol, objectId, objectName), fileName, relativeFileDir);
     }
 
@@ -84,4 +110,11 @@ export class QueryBuilder extends ObjectBuilder {
         
     //#endregion
 
+    //#region Helper Methods
+
+    private getDefaultQueryName(tableSymbol: ALSymbolInfo) : string {
+        return `${tableSymbol.symbolName.trim()} Query`;
+    }
+    
+    //#endregion
 }

--- a/src/objectbuilders/queryBuilder.ts
+++ b/src/objectbuilders/queryBuilder.ts
@@ -32,7 +32,8 @@ export class QueryBuilder extends ObjectBuilder {
         }
 
         let fileName : string = await FileBuilder.getPatternGeneratedFullObjectFileName(objType, objectId, objectName);
-        this.showNewDocument(this.buildQueryForTable(tableSymbol, objectId, objectName), fileName, objType);
+        let relativeFileDir: string = await this.getRelativeFileDir(objType);
+        this.showNewDocument(this.buildQueryForTable(tableSymbol, objectId, objectName), fileName, relativeFileDir);
     }
 
     //#endregion

--- a/src/objectbuilders/reportBuilder.ts
+++ b/src/objectbuilders/reportBuilder.ts
@@ -13,6 +13,28 @@ export class ReportBuilder extends ObjectBuilder {
 
     //#region Wizards with UI
 
+    async showMultiReportWizard(tableSymbols: ALSymbolInfo[]) {
+        if (!FileBuilder.checkCrsExtensionFileNamePatternRequired())
+            return;
+
+        const objType : ALSymbolKind = ALSymbolKind.Report;
+
+        let startObjectId: number = await this.getObjectId(`Please enter a starting ID for the report objects.`, 0);
+        if (startObjectId < 0) {
+            return;
+        }
+
+        let relativeFileDir: string = await this.getRelativeFileDir(objType);
+
+        for (let i = 0; i < tableSymbols.length; i++) {
+            let tableSymbol = tableSymbols[i];
+            let objectId: number = startObjectId + i;
+            let objectName : string = this.getDefaultReportName(tableSymbol);
+
+            await this.createAndShowNewReport(tableSymbol, objType, objectId, objectName, relativeFileDir);
+        }
+    }
+
     async showReportWizard(tableSymbol : ALSymbolInfo) {
         if (!FileBuilder.checkCrsFileNamePatternRequired())
             return;
@@ -24,15 +46,19 @@ export class ReportBuilder extends ObjectBuilder {
             return;
         }
 
-        let objectName : string = tableSymbol.symbolName.trim() + " Report";
+        let objectName : string = this.getDefaultReportName(tableSymbol);
         objectName = await this.getObjectName("Please enter a name for the report object.", objectName);
         
         if (!objectName) {
             return;
         }
 
-        let fileName : string = await FileBuilder.getPatternGeneratedFullObjectFileName(objType, objectId, objectName);
         let relativeFileDir: string = await this.getRelativeFileDir(objType);
+        await this.createAndShowNewReport(tableSymbol, objType, objectId, objectName, relativeFileDir);
+    }
+
+    private async createAndShowNewReport(tableSymbol: ALSymbolInfo, objType: ALSymbolKind, objectId: number, objectName: string, relativeFileDir: string) {
+        let fileName : string = await FileBuilder.getPatternGeneratedFullObjectFileName(objType, objectId, objectName);
         this.showNewDocument(this.buildReportForTable(tableSymbol, objectId, objectName), fileName, relativeFileDir);
     }
 
@@ -98,4 +124,11 @@ export class ReportBuilder extends ObjectBuilder {
 
     //#endregion
 
+    //#region Helper Methods
+
+    private getDefaultReportName(tableSymbol: ALSymbolInfo) : string {
+        return `${tableSymbol.symbolName.trim()} Report`;
+    }
+    
+    //#endregion
 }

--- a/src/objectbuilders/reportBuilder.ts
+++ b/src/objectbuilders/reportBuilder.ts
@@ -32,7 +32,8 @@ export class ReportBuilder extends ObjectBuilder {
         }
 
         let fileName : string = await FileBuilder.getPatternGeneratedFullObjectFileName(objType, objectId, objectName);
-        this.showNewDocument(this.buildReportForTable(tableSymbol, objectId, objectName), fileName, objType);
+        let relativeFileDir: string = await this.getRelativeFileDir(objType);
+        this.showNewDocument(this.buildReportForTable(tableSymbol, objectId, objectName), fileName, relativeFileDir);
     }
 
     //#endregion

--- a/src/objectbuilders/tableExtBuilder.ts
+++ b/src/objectbuilders/tableExtBuilder.ts
@@ -13,6 +13,28 @@ export class TableExtBuilder extends ObjectBuilder {
 
     //#region Wizards with UI
 
+    async showMultiTableExtWizard(tableSymbols: ALSymbolInfo[]) {
+        if (!FileBuilder.checkCrsExtensionFileNamePatternRequired())
+            return;
+
+        const extObjType : ALSymbolKind = ALSymbolKind.TableExtension;
+
+        let startObjectId: number = await this.getObjectId("Please enter a starting ID for the table extensions.", 0);
+        if (startObjectId < 0) {
+            return;
+        }
+
+        let relativeFileDir: string = await this.getRelativeFileDir(extObjType);
+
+        for (let i = 0; i < tableSymbols.length; i++) {
+            let tableSymbol = tableSymbols[i];
+            let extObjectId: number = startObjectId + i;
+            let extObjectName: string = await FileBuilder.getPatternGeneratedExtensionObjectName(extObjType, extObjectId, tableSymbol);
+
+            await this.createAndShowNewTableExtension(tableSymbol, extObjType, extObjectId, extObjectName, relativeFileDir);
+        }
+    }
+
     async showTableExtWizard(tableSymbol : ALSymbolInfo) {
         if (!FileBuilder.checkCrsExtensionFileNamePatternRequired())
             return;
@@ -30,8 +52,12 @@ export class TableExtBuilder extends ObjectBuilder {
             return;
         }
         
-        let fileName : string = await FileBuilder.getPatternGeneratedExtensionObjectFileName(extObjType, extObjectId, extObjectName, tableSymbol);
         let relativeFileDir: string = await this.getRelativeFileDir(extObjType);
+        await this.createAndShowNewTableExtension(tableSymbol, extObjType, extObjectId, extObjectName, relativeFileDir);
+    }
+
+    private async createAndShowNewTableExtension(tableSymbol: ALSymbolInfo, extObjType: ALSymbolKind, extObjectId: number, extObjectName: string, relativeFileDir: string) {
+        let fileName : string = await FileBuilder.getPatternGeneratedExtensionObjectFileName(extObjType, extObjectId, extObjectName, tableSymbol);
         this.showNewDocument(this.buildTableExtForTable(tableSymbol, extObjectId, extObjectName), fileName, relativeFileDir);
     }
 

--- a/src/objectbuilders/tableExtBuilder.ts
+++ b/src/objectbuilders/tableExtBuilder.ts
@@ -14,7 +14,7 @@ export class TableExtBuilder extends ObjectBuilder {
     //#region Wizards with UI
 
     async showMultiTableExtWizard(tableSymbols: ALSymbolInfo[]) {
-        if (!FileBuilder.checkCrsExtensionFileNamePatternRequired())
+        if (!FileBuilder.checkCrsExtensionFileNamePatternRequired() || !FileBuilder.checkCrsExtensionObjectNamePatternRequired(true))
             return;
 
         const extObjType : ALSymbolKind = ALSymbolKind.TableExtension;
@@ -36,7 +36,7 @@ export class TableExtBuilder extends ObjectBuilder {
     }
 
     async showTableExtWizard(tableSymbol : ALSymbolInfo) {
-        if (!FileBuilder.checkCrsExtensionFileNamePatternRequired())
+        if (!FileBuilder.checkCrsExtensionFileNamePatternRequired() || !FileBuilder.checkCrsExtensionObjectNamePatternRequired(false))
             return;
             
         const extObjType : ALSymbolKind = ALSymbolKind.TableExtension;

--- a/src/objectbuilders/tableExtBuilder.ts
+++ b/src/objectbuilders/tableExtBuilder.ts
@@ -31,7 +31,8 @@ export class TableExtBuilder extends ObjectBuilder {
         }
         
         let fileName : string = await FileBuilder.getPatternGeneratedExtensionObjectFileName(extObjType, extObjectId, extObjectName, tableSymbol);
-        this.showNewDocument(this.buildTableExtForTable(tableSymbol, extObjectId, extObjectName), fileName, extObjType);
+        let relativeFileDir: string = await this.getRelativeFileDir(extObjType);
+        this.showNewDocument(this.buildTableExtForTable(tableSymbol, extObjectId, extObjectName), fileName, relativeFileDir);
     }
 
     //#endregion

--- a/src/objectbuilders/xmlPortBuilder.ts
+++ b/src/objectbuilders/xmlPortBuilder.ts
@@ -50,7 +50,8 @@ export class XmlPortBuilder extends ObjectBuilder {
             return;
         
         let fileName : string = await FileBuilder.getPatternGeneratedFullObjectFileName(objType, objectId, objectName);
-        this.showNewDocument(this.buildXmlPortForTable(tableSymbol, objectId, objectName, (selectedNodeType.label == fieldAsElementText)), fileName, objType);
+        let relativeFileDir: string = await this.getRelativeFileDir(objType);
+        this.showNewDocument(this.buildXmlPortForTable(tableSymbol, objectId, objectName, (selectedNodeType.label == fieldAsElementText)), fileName, relativeFileDir);
     }
 
     //#endregion

--- a/src/objectlibrary/alObjectLibrariesCollection.ts
+++ b/src/objectlibrary/alObjectLibrariesCollection.ts
@@ -56,4 +56,11 @@ export class ALObjectLibrariesCollection {
         return null;
     }
 
+    findALSymbolInfoList(objectType: string, objectIds: number[]) : ALSymbolInfo[] {
+        let symbolInfoList: ALSymbolInfo[] = [];
+        objectIds.forEach(objectId => {
+            symbolInfoList.push(this.findALSymbolInfo(objectType, objectId));
+        });
+        return symbolInfoList;
+    }
 }


### PR DESCRIPTION
Hi @anzwdev,

Here is another pull request which introduces capabilities for multi-select in the AL Object Browser.

![image](https://user-images.githubusercontent.com/7383241/54498552-25d8a880-4909-11e9-8e96-b97c00065f11.png)

#### Multi Select
From the AL Object Browser you can now select multiple rows.
For this you can use either **Ctrl+Click** (selecting/deselecting single rows), **Shift+Click** (selecting/deselecting all rows) or "Ctrl+A" (select all rows in the filter).
This feature also works in combination with the earlier introduced filtering functionality.
Please note that if you select rows with multiple different object types, then running a command will filter on the object type of the row from which you opened the context menu.

#### Commands to generate Multiple Objects
The commands from the context menu (e.g., "New Page Extension") now also work based on your selection.
If you only select only a single row, the commands will work like they used to.
If you select multiple rows, then the commands will generate new objects for each selection.
The "Run in Webclient" command is an exception, it will always only apply to a single row (i.e., your pivot row).

Please note that the commands won't show prompts for each object, but instead only a start object ID will be requested from the user via a prompt.
Also, when multiple objects are generated, the prompt for object names will not be shown. Instead objects will always be generated from a pattern (e.g., the `CRS.ExtensionObjectNamePattern` setting).

The generation of multiple objects works both with the "alOutline.autoGenerateFiles" enabled and disabled. If it is enabled you will get files, if it is disabled you will get "Untitled-*" documents in your editor.

I have also updated the checks on the VS Code workspace/user settings a bit. For example, if you generate multiple extension objects, then the extension object name pattern should be set.

Please let me know what you think about this addition and/or if you have any further comments or suggestions.