### PR TITLE
DevTools language server error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.0.8
+ - Error handling added to DevTools language server client to prevent crashes on unsupported platforms (Mac, Linux)
+
 ## 1.0.7
  - New al objects wizards:
    - Page Wizard

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "al-code-outline",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "al-code-outline",
 	"displayName": "AZ AL Dev Tools/AL Code Outline",
 	"description": "AZ AL Development Tools: AL code outline, object browser, object creators",
-	"version": "1.0.7",
+	"version": "1.0.8",
 	"publisher": "andrzejzwierzchowski",
 	"engines": {
 		"vscode": "^1.30.0"

--- a/src/langserver/toolsLangServerClient.ts
+++ b/src/langserver/toolsLangServerClient.ts
@@ -35,58 +35,88 @@ export class ToolsLangServerClient implements vscode.Disposable {
     }
 
     protected initialize() {
-        //find binaries path
-        let langServerPath : string = this._context.asAbsolutePath("bin/AZALDevToolsServer.exe");
-        //start child process
-        this._childProcess = cp.spawn(langServerPath, [this._alExtensionPath]);
-        this._connection = rpc.createMessageConnection(
-            new rpc.StreamMessageReader(this._childProcess.stdout),
-            new rpc.StreamMessageWriter(this._childProcess.stdin));
-        this._connection.listen();
+        try {
+            //find binaries path
+            let langServerPath : string = this._context.asAbsolutePath("bin/AZALDevToolsServer.exe");
+            //start child process
+            this._childProcess = cp.spawn(langServerPath, [this._alExtensionPath]);
+            if (this._childProcess) {
+                this._connection = rpc.createMessageConnection(
+                    new rpc.StreamMessageReader(this._childProcess.stdout),
+                    new rpc.StreamMessageWriter(this._childProcess.stdin));
+                this._connection.listen();
+            }
+        }
+        catch (e) {
+        }
     }
 
     public async getALDocumentSymbols(params : ToolsDocumentSymbolsRequest) : Promise<ToolsDocumentSymbolsResponse|undefined> {
-        if (!this._connection)
+        try {
+            if (!this._connection)
+                return undefined;
+                    
+            let reqType = new rpc.RequestType<ToolsDocumentSymbolsRequest, ToolsDocumentSymbolsResponse, void, void>('al/documentsymbols');
+            let val = await this._connection.sendRequest(reqType, params);
+            return val;
+        }
+        catch (e) {
             return undefined;
-                
-        let reqType = new rpc.RequestType<ToolsDocumentSymbolsRequest, ToolsDocumentSymbolsResponse, void, void>('al/documentsymbols');
-        let val = await this._connection.sendRequest(reqType, params);
-        return val;
+        }
     }
 
     public async getAppPackageSymbols(params : ToolsPackageSymbolsRequest) : Promise<ToolsPackageSymbolsResponse|undefined> {
-        if (!this._connection)
+        try {
+            if (!this._connection)
+                return undefined;
+                    
+            let reqType = new rpc.RequestType<ToolsPackageSymbolsRequest, ToolsPackageSymbolsResponse, void, void>('al/packagesymbols');
+            let val = await this._connection.sendRequest(reqType, params);
+            return val;
+        }
+        catch (e) {
             return undefined;
-                
-        let reqType = new rpc.RequestType<ToolsPackageSymbolsRequest, ToolsPackageSymbolsResponse, void, void>('al/packagesymbols');
-        let val = await this._connection.sendRequest(reqType, params);
-        return val;
+        }
     }
 
     public async getProjectSymbols(params : ToolsProjectSymbolsRequest) : Promise<ToolsProjectSymbolsResponse|undefined> {
-        if (!this._connection)
-            return undefined;
+        try {
+            if (!this._connection)
+                return undefined;
                 
-        let reqType = new rpc.RequestType<ToolsProjectSymbolsRequest, ToolsProjectSymbolsResponse, void, void>('al/projectsymbols');
-        let val = await this._connection.sendRequest(reqType, params);
-        return val;
+            let reqType = new rpc.RequestType<ToolsProjectSymbolsRequest, ToolsProjectSymbolsResponse, void, void>('al/projectsymbols');
+            let val = await this._connection.sendRequest(reqType, params);
+            return val;
+        }
+        catch (e) {
+            return undefined;
+        }
     }
 
     public async getLibrarySymbolsDetails(params : ToolsLibrarySymbolsDetailsRequest) : Promise<ToolsLibrarySymbolsDetailsResponse|undefined> {
-        if (!this._connection)
-            return undefined;
+        try {
+            if (!this._connection)
+                return undefined;
                 
-        let reqType = new rpc.RequestType<ToolsLibrarySymbolsDetailsRequest, ToolsLibrarySymbolsDetailsResponse, void, void>('al/librarysymbolsdetails');
-        let val = await this._connection.sendRequest(reqType, params);
-        return val;
+            let reqType = new rpc.RequestType<ToolsLibrarySymbolsDetailsRequest, ToolsLibrarySymbolsDetailsResponse, void, void>('al/librarysymbolsdetails');
+            let val = await this._connection.sendRequest(reqType, params);
+            return val;
+        }
+        catch (e) {
+            return undefined;
+        }
     }
 
     public closeSymbolsLibrary(params: ToolsCloseSymbolsLibraryRequest) {
-        if (!this._connection)
-            return undefined;
+        try {
+            if (!this._connection)
+                return undefined;
 
-        let reqType = new rpc.NotificationType<ToolsCloseSymbolsLibraryRequest, void>('al/closesymbolslibrary');;
-        this._connection.sendNotification(reqType, params);
+            let reqType = new rpc.NotificationType<ToolsCloseSymbolsLibraryRequest, void>('al/closesymbolslibrary');;
+            this._connection.sendNotification(reqType, params);
+        }
+        catch (e) {
+        }
     }
 
     public isEnabled() : boolean {

--- a/src/symbollibraries/azDocumentSymbolsLibrary.ts
+++ b/src/symbollibraries/azDocumentSymbolsLibrary.ts
@@ -103,6 +103,8 @@ export class AZDocumentSymbolsLibrary extends AZSymbolsLibrary {
     //#region update field names from our language server with values returned by Microsoft AL Language Extension 
     
     protected mergeFieldSymbolNames(azSymbol : AZSymbolInformation, vsFieldSymbols : vscode.DocumentSymbol[]) {
+        if (!azSymbol)
+            return;
         if ((azSymbol.kind == AZSymbolKind.PageField) || 
             (azSymbol.kind == AZSymbolKind.QueryColumn) || 
             (azSymbol.kind == AZSymbolKind.QueryFilter)) {


### PR DESCRIPTION
Error handling added to DevTools language server client to prevent crashes on unsupported platforms (Mac, Linux)