### PR TITLE
"Expand/Collapse nodes" command in Symbols Tree View

### DIFF
--- a/htmlresources/actionimagebrowser/imagebrowser.html
+++ b/htmlresources/actionimagebrowser/imagebrowser.html
@@ -12,7 +12,7 @@
     </header>
     <body>
         <div id="search">
-            <input id="searchname" type="text" class="searchinput" tabindex="1" placeholder="Name filter, Eg: *Item*, *Setup*">
+            <input id="searchname" type="text" class="searchinput" tabindex="1" placeholder="Name filter, e.g., *Item*, *Setup*">
             <button class="btn" id="searchbtn" tabindex="2">Search</button>
         </div>
         <div id="content" tabindex="3">

--- a/htmlresources/alsymbolsbrowser/symbolsbrowser.html
+++ b/htmlresources/alsymbolsbrowser/symbolsbrowser.html
@@ -34,8 +34,8 @@
                 <option value="Enum">Enums</option>
                 <option value="DotNetPackage">DotNet Packages</option>
             </select>            
-            <input type="text" id="searchid" name="searchid" tabindex="2" class="searchinput" placeholder="Id filter. Eg: 22, 10..50, &gt;20&amp;&lt;30">
-            <input type="text" id="searchname" name="searchname" tabindex="3" class="searchinput" placeholder="Name filter, Eg: *Item*, *Customer*">
+            <input type="text" id="searchid" name="searchid" tabindex="2" class="searchinput" placeholder="Id filter, e.g., 22, 10..50, &gt;20&amp;&lt;30">
+            <input type="text" id="searchname" name="searchname" tabindex="3" class="searchinput" placeholder="Name filter, e.g., *Item*, *Customer*">
             <button class="btn" id="searchbtn" tabindex="3">Search</button>
             <button class="btn" id="listbtn" tabindex="3">List View</button>
         </div>
@@ -57,7 +57,7 @@
                     </div>
                 </div>
                 <div class="treefiltercont">
-                    <input tabindex="1" id="selobjfilter" class="treefiltertext" type="text" placeholder="Filter, Eg: *Address*, Entry*">
+                    <input tabindex="1" id="selobjfilter" class="treefiltertext" type="text" placeholder="Filter, e.g., *Address*, Entry*">
                     <button tabindex="2" id="selobjfilterbtn" class="treefilterbtn">Filter</button>
         
                 </div>

--- a/htmlresources/lib/symbolstreecontrol/symbolstreecontrol.js
+++ b/htmlresources/lib/symbolstreecontrol/symbolstreecontrol.js
@@ -444,20 +444,52 @@ class SymbolsTreeControl {
 
     //#region Expand/Collapse
 
+    isNodeCollapsed(node) {
+        let element = $(node)[0];
+        let symbol = element.alsymbolnode;
+        if (!symbol || !symbol.collapsed) {
+            return false;
+        }
+        return true;
+    }
+
+    toggleChildNodes(node) {
+        // Retrieve all child-nodes that can be expanded/collapsed
+        let nodeList = $(node).next('.treelist').children('.treeitem').children('.shead').not('.sheadnoexp');
+        if (nodeList.length === 0) {
+            return;
+        }
+        
+        // Check whether we need to expand or collapse based on the first child
+        let firstChildNode = nodeList[0];
+        let isFirstChildCollapsed = this.isNodeCollapsed(firstChildNode);
+
+        for (let i = 0; i < nodeList.length; i++) {
+            this.expandOrCollapseNode(nodeList[i], !isFirstChildCollapsed);
+        }
+    }
+
     toggleNode(node) {
+        let isCollapsed = this.isNodeCollapsed(node);
+        this.expandOrCollapseNode(node, !isCollapsed);
+    }
+
+    expandOrCollapseNode(node, collapse) {
         let element = $(node)[0];
         let symbol = element.alsymbolnode;
         if (symbol) {
             if ((symbol.childSymbols) && (symbol.childSymbols.length > 0)) {
-                symbol.collapsed = !symbol.collapsed;
+                symbol.collapsed = collapse;
                 if (symbol.collapsed)
                     $(node).next('.treelist').hide();
                 else
                     $(node).next('.treelist').show();
                 node.className = this.getSymbolCssClass(symbol);
             }
-        } else
+        } 
+        else {
             $(node).next('.treelist').toggle();
+        }
     }
 
     //#endregion

--- a/htmlresources/objectbrowser/objectbrowser.html
+++ b/htmlresources/objectbrowser/objectbrowser.html
@@ -30,8 +30,8 @@
                 <option value="Enum">Enums</option>
                 <option value="DotNetPackage">DotNet Packages</option>
             </select>
-            <input type="text" id="searchid" name="searchid" class="searchinput" tabindex="3" placeholder="Id filter. Eg: 22, 10..50, &gt;20&amp;&lt;30">
-            <input type="text" id="searchname" name="searchname" class="searchinput" tabindex="3" placeholder="Name filter, Eg: *Item*, *Customer*">
+            <input type="text" id="searchid" name="searchid" class="searchinput" tabindex="3" placeholder="Id filter, e.g., 22, 10..50, &gt;20&amp;&lt;30">
+            <input type="text" id="searchname" name="searchname" class="searchinput" tabindex="3" placeholder="Name filter, e.g., *Item*, *Customer*">
             <button class="btn" id="searchbtn" tabindex="4">Search</button>
             <button class="btn" id="treebtn" tabindex="5">Tree View</button>
         </div>

--- a/htmlresources/symbolstreeview/js/symbolstreeview.js
+++ b/htmlresources/symbolstreeview/js/symbolstreeview.js
@@ -71,16 +71,22 @@ class SymbolsTreeView {
         $('#symbols').contextMenu({
             selector: '.shead', 
             callback: function(key, options) {
-                me.sendMessage({
-                    command : key,
-                    path : me._symTree.getNodePath(this),
-                    selpaths : me._symTree.getSelectedPaths(this),
-                    uid : $(this).data('uid'),
-                    kind : $(this).data('kind')
-                });
+                if (key === "expandcollapse") {
+                    me._symTree.toggleChildNodes(this);
+                }
+                else {
+                    me.sendMessage({
+                        command : key,
+                        path : me._symTree.getNodePath(this),
+                        selpaths : me._symTree.getSelectedPaths(this),
+                        uid : $(this).data('uid'),
+                        kind : $(this).data('kind')
+                    });
+                }
             },
             items: {
                 "definition": {name: "Go to definition"},
+                "expandcollapse": {name: "Expand/collapse nodes"},
             }
         });
     }

--- a/htmlresources/symbolstreeview/symbolstreeview.html
+++ b/htmlresources/symbolstreeview/symbolstreeview.html
@@ -17,7 +17,7 @@
     </header>
     <body style="margin:0;padding:0">
         <div class="treefiltercont">
-            <input tabindex="1" id="filter" type="text" placeholder="Filter, Eg: *Address*, Entry*">
+            <input tabindex="1" id="filter" type="text" placeholder="Filter, e.g., *Address*, Entry*">
             <button tabindex="2" id="filterbtn" class="treefilterbtn">Filter</button>
         </div>
         <div id="symbols" tabindex="3" class="symbolscont">Loading symbols, please wait...</div>


### PR DESCRIPTION
Dear @anzwdev,
This PR introduces a new "Expand/Collapse nodes" command in the Symbols Tree View, to expand or collapse all childnodes.

![expandCollapseNodes](https://user-images.githubusercontent.com/7383241/73606799-3c81ff80-45ae-11ea-8656-ebb9b3678c14.png)

It's slightly different from what I suggested in #73: it has become a command in the context-menu of the symbols tree view.
I think it is better to have it in the context-menu because then you can more specifically expand/collapse nodes just for a specific group of nodes.
It's also applied to the symbols tree view, because it's more useful there (although we could also apply it to the object browser tree view, but didn't do that yet, because I think it's less useful there).

Please let me know what you think about this addition and/or if you have any further comments or suggestions.