### PR TITLE
New Table Extension Wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This extension was originally named 'AL Code Outline' because it started as AL c
 
 Extensions add new "New AL File Wizard" item to EXPLORER context menu. It allows to run one of these wizards to create new AL object file:
    - Table Wizard
+   - Table Extension Wizard
    - Page Wizard
    - Codeunit Wizard
    - Interface Wizard

--- a/htmlresources/altableextwizard/altableextwizard.html
+++ b/htmlresources/altableextwizard/altableextwizard.html
@@ -3,24 +3,27 @@
     <head>
         <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ##CSPSOURCE## https: data:; script-src ##CSPSOURCE## 'unsafe-eval'; style-src ##CSPSOURCE##; font-src ##CSPSOURCE##;" />
         <script src="##EXTENSIONPATH##/htmlresources/lib/autocomplete/autocomplete.js"></script>
+        <script src="##EXTENSIONPATH##/htmlresources/lib/helpers/htmlhelper.js"></script>
         <script src="##EXTENSIONPATH##/htmlresources/lib/azgridview/azgridview.js"></script>
         <script src="##EXTENSIONPATH##/htmlresources/lib/azgridview/tablefieldsgridview.js"></script>
-        <script src="##EXTENSIONPATH##/htmlresources/altablewizard/js/altablewizard.js"></script>
+        <script src="##EXTENSIONPATH##/htmlresources/lib/filteredlist/filteredlist.js"></script>
+        <script src="##EXTENSIONPATH##/htmlresources/lib/wizards/tablebasedobjectwizard.js"></script>
+        <script src="##EXTENSIONPATH##/htmlresources/altableextwizard/js/altableextwizard.js"></script>
         <link rel="stylesheet" type="text/css" href="##EXTENSIONPATH##/htmlresources/lib/autocomplete/autocomplete.css">
         <link rel="stylesheet" type="text/css" href="##EXTENSIONPATH##/htmlresources/lib/azgridview/azgridview.css">
         <link rel="stylesheet" type="text/css" href="##EXTENSIONPATH##/htmlresources/lib/wizards/wizards.css">
-        <link rel="stylesheet" type="text/css" href="##EXTENSIONPATH##/htmlresources/altablewizard/css/altablewizard.css">
+        <link rel="stylesheet" type="text/css" href="##EXTENSIONPATH##/htmlresources/altableextwizard/css/altableextwizard.css">
     </head>
     <body>
         <div id="main" class="main">
             <div id="header" class="header">
-                <div class="title">New Table Wizard</div>
+                <div class="title">New Table Extension Wizard</div>
             </div>
 
             <div id="wizardstep1" class="wizard">
 
                 <div class="formline">
-                    <div class="formheader">Please enter table properties.</div>
+                    <div class="formheader">Please enter table extension properties.</div>
                 </div>
                         
                 <div class="formline">
@@ -36,6 +39,13 @@
                         <input type="text" id="objectname" name="objectname" class="fulltext">
                     </div>
                 </div>
+
+                <div class="formline">
+                    <div class="formcaption">Extends:</div>
+                    <div class="formfield">
+                        <input type="text" id="srctable" name="srctable" class="fulltext" />
+                    </div>
+                </div>
     
                 <div id="fieldsgrid" class="formarea">                    
                 </div>
@@ -43,6 +53,8 @@
             </div>
 
             <div id="footer" class="footer">
+                <button id="prevBtn" class="button">Previous</button>
+                <button id="nextBtn" class="button">Next</button>
                 <button id="finishBtn" class="button">Finish</button>
                 <button id="cancelBtn" class="button">Cancel</button>
             </div>

--- a/htmlresources/altableextwizard/css/altableextwizard.css
+++ b/htmlresources/altableextwizard/css/altableextwizard.css
@@ -1,0 +1,7 @@
+.azgridviewcont {
+    margin: 0 10px;
+    flex: 1 1 100px;
+}
+.autocomplete {
+    white-space: nowrap;
+}

--- a/htmlresources/altableextwizard/js/altableextwizard.js
+++ b/htmlresources/altableextwizard/js/altableextwizard.js
@@ -1,0 +1,94 @@
+class TableExtWizard extends TableBasedObjectWizard {
+
+    constructor() {
+        super(1);
+
+        this._fieldsgrid = new TableFieldsGridView();
+        htmlHelper.hideById("prevBtn");
+        htmlHelper.hideById("nextBtn");
+    }
+
+    onMessage(message) {    
+        super.onMessage(message); 
+
+        switch (message.command) {
+            case 'setTypes':
+                this.setTypes(message.data);
+                break;
+        }
+    }
+
+    setTables(data) {
+        super.setTables(data);
+        this.sendMessage({
+            command : "loadTypes"
+        });
+    }
+
+    setData(data) {
+        super.setData(data);
+
+        //initialize inputs
+        document.getElementById("objectid").value = this._data.objectId;
+        document.getElementById("objectname").value = this._data.objectName;
+        document.getElementById("srctable").value = this._data.selectedTable;
+        //initialize field list
+        if (this._data.fields) {
+            this._fieldsgrid.setData(this._data.fields);
+        }
+        else {
+            this._fieldsgrid.setData([]);
+        }
+        this.loadTables();
+    }
+
+    setTypes(types) {
+        this._fieldsgrid._columns[2].autocomplete = types;
+    }
+
+    onFinish() {
+        this.collectStepData(true);
+
+        if (!this.canFinish()) {
+            return;
+        }
+            
+        this.sendMessage({
+            command: "finishClick",
+            data: {
+                objectId : this._data.objectId,
+                objectName : this._data.objectName,
+                selectedTable : this._data.selectedTable,
+                fields: this._data.fields
+            }
+        });
+    }
+
+    collectStepData(finishSelected) {
+        this._data.objectId = document.getElementById("objectid").value;
+        this._data.objectName = document.getElementById("objectname").value;
+        this._data.selectedTable = document.getElementById("srctable").value;
+        this._data.fields = this._fieldsgrid.getData();
+    }
+
+    canFinish() {
+        if (!super.canFinish) {
+            return false;
+        }
+
+        if ((!this._data.selectedTable) || (this._data.selectedTable == '')) {
+            this.sendMessage({
+                command: 'showError',
+                message: 'Please enter a target object name.'
+            });
+            return false;
+        }
+        return true;
+    }
+}
+
+var wizard;
+
+window.onload = function() {
+    wizard = new TableExtWizard();
+};

--- a/htmlresources/altablewizard/js/altablewizard.js
+++ b/htmlresources/altablewizard/js/altablewizard.js
@@ -6,19 +6,7 @@ class TableWizard {
         this._vscode = acquireVsCodeApi();
 
         //initialize controls
-        this._fieldsgrid = new AZGridView('fieldsgrid', 
-            [{name: 'id', caption: 'Id', style: 'width: 80px;'},
-            {name: 'name', caption: 'Name', style: 'width: 50%;'},
-            //{name: 'caption', caption: 'Caption', style: 'width: 30%'},
-            {name: 'dataType', caption: 'Data Type', style: 'width: 20%', autocomplete: [                
-                'Blob', 'Boolean', 'Code', 'Date', 'DateFormula', 'DateTime', 'Decimal', 'Duration',
-                'Enum', 'Guid', 'Integer', 'Media', 'MediaSet', 'Option', 'RecordId', 'TableFilter',
-                'Text', 'Time']},
-            {name: 'dataClassification', caption: 'Data Classification', style: 'width: 20%', autocomplete: [
-                'AccountData', 'CustomerContent', 'EndUserIdentifiableInformation', 'EndUserPseudonymousIdentifiers',
-                'OrganizationIdentifiableInformation', 'SystemMetadata', 'ToBeClassified']},
-            {name: 'length', caption: 'Length', style: 'width:100px'}],
-            undefined, undefined, 'Loading data...', true);
+        this._fieldsgrid = new TableFieldsGridView();
 
         // Handle messages sent from the extension to the webview
         window.addEventListener('message', event => {

--- a/htmlresources/lib/azgridview/tablefieldsgridview.js
+++ b/htmlresources/lib/azgridview/tablefieldsgridview.js
@@ -1,0 +1,18 @@
+class TableFieldsGridView extends AZGridView {
+
+    constructor() {
+        super('fieldsgrid', 
+            [{name: 'id', caption: 'Id', style: 'width: 80px;'},
+            {name: 'name', caption: 'Name', style: 'width: 50%;'},
+            //{name: 'caption', caption: 'Caption', style: 'width: 30%'},
+            {name: 'dataType', caption: 'Data Type', style: 'width: 20%', autocomplete: [                
+                'Blob', 'Boolean', 'Code', 'Date', 'DateFormula', 'DateTime', 'Decimal', 'Duration',
+                'Enum', 'Guid', 'Integer', 'Media', 'MediaSet', 'Option', 'RecordId', 'TableFilter',
+                'Text', 'Time']},
+            {name: 'dataClassification', caption: 'Data Classification', style: 'width: 20%', autocomplete: [
+                'AccountData', 'CustomerContent', 'EndUserIdentifiableInformation', 'EndUserPseudonymousIdentifiers',
+                'OrganizationIdentifiableInformation', 'SystemMetadata', 'ToBeClassified']},
+            {name: 'length', caption: 'Length', style: 'width:100px'}],
+            undefined, undefined, 'Loading data...', true);
+    }
+}

--- a/src/objectwizards/syntaxbuilders/alTableExtSyntaxBuilder.ts
+++ b/src/objectwizards/syntaxbuilders/alTableExtSyntaxBuilder.ts
@@ -1,0 +1,29 @@
+import * as vscode from 'vscode';
+import { ALTableExtWizardData } from "../wizards/alTableExtWizardData";
+import { ALSyntaxWriter } from "../../allanguage/alSyntaxWriter";
+
+export class ALTableExtSyntaxBuilder {
+    constructor() {
+    }
+
+    buildFromTableExtWizardData(destUri: vscode.Uri | undefined, data: ALTableExtWizardData) : string {
+        //generate file content
+        let writer : ALSyntaxWriter = new ALSyntaxWriter(destUri);
+
+        writer.writeStartExtensionObject("tableextension", data.objectId, data.objectName, data.selectedTable);
+
+        //write fields here
+        writer.writeStartFields();
+
+        for (let i = 0; i < data.fields.length; i++) {
+            writer.writeTableField(data.fields[i].id, data.fields[i].name, data.fields[i].type, data.fields[i].length,
+                data.fields[i].dataClassification);
+        }
+
+        writer.writeEndFields();
+
+        writer.writeEndObject();
+
+        return writer.toString();
+    }
+}

--- a/src/objectwizards/wizards/alTableExtWizard.ts
+++ b/src/objectwizards/wizards/alTableExtWizard.ts
@@ -1,0 +1,33 @@
+'use strict';
+
+import { ALObjectWizard } from "./alObjectWizard";
+import { ALLangServerProxy } from '../../allanguage/alLangServerProxy';
+import { ALTableExtWizardData } from "./alTableExtWizardData";
+import { ALTableExtWizardPage } from "./alTableExtWizardPage";
+import { DevToolsExtensionContext } from "../../devToolsExtensionContext";
+import { ALObjectWizardSettings } from "./alObjectWizardSettings";
+
+export class ALTableExtWizard extends ALObjectWizard {
+    
+    constructor(toolsExtensionContext : DevToolsExtensionContext, newLabel: string, newDescription : string, newDetails: string) {
+        super(toolsExtensionContext, newLabel, newDescription, newDetails);
+    }
+
+    run(settings: ALObjectWizardSettings) {
+        super.run(settings);
+        this.runAsync(settings);
+    }
+
+    protected async runAsync(settings: ALObjectWizardSettings) {
+        let alLangProxy : ALLangServerProxy = new ALLangServerProxy();
+        let objectId : string = await alLangProxy.getNextObjectId(settings.getDestDirectoryUri(), "tableextension");
+
+        let wizardData : ALTableExtWizardData = new ALTableExtWizardData();
+        wizardData.objectId = objectId;
+        wizardData.objectName = '';
+        wizardData.selectedTable = '';
+        let wizardPage : ALTableExtWizardPage = new ALTableExtWizardPage(this._toolsExtensionContext, settings, wizardData);
+        wizardPage.show();
+    }
+
+} 

--- a/src/objectwizards/wizards/alTableExtWizardData.ts
+++ b/src/objectwizards/wizards/alTableExtWizardData.ts
@@ -1,0 +1,14 @@
+'use strict';
+
+//import * as vscode from 'vscode';
+import { ALTableBasedWizardData } from "./alTableBasedWizardData";
+import { ALTableWizardFieldData } from "./alTableWizardFieldData";
+
+export class ALTableExtWizardData extends ALTableBasedWizardData {
+    fields: ALTableWizardFieldData[];
+
+    constructor() {
+        super();
+        this.fields = [];
+    }
+}

--- a/src/objectwizards/wizards/alTableExtWizardPage.ts
+++ b/src/objectwizards/wizards/alTableExtWizardPage.ts
@@ -1,0 +1,66 @@
+'use strict';
+
+import * as path from 'path';
+import { DevToolsExtensionContext } from '../../devToolsExtensionContext';
+import { ALObjectWizardSettings } from './alObjectWizardSettings';
+import { ALTableExtSyntaxBuilder } from '../syntaxbuilders/alTableExtSyntaxBuilder';
+import { ALTableBasedWizardPage } from './alTableBasedWizardPage';
+import { ALTableExtWizardData } from './alTableExtWizardData';
+import { WizardTableFieldHelper } from './wizardTableFieldHelper';
+
+export class ALTableExtWizardPage extends ALTableBasedWizardPage {
+    private _tableExtWizardData : ALTableExtWizardData;
+    
+    constructor(toolsExtensionContext : DevToolsExtensionContext, settings: ALObjectWizardSettings, data : ALTableExtWizardData) {
+        super(toolsExtensionContext, "AL Table Extension Wizard", settings, data);
+        this._tableExtWizardData = data;
+    }
+
+    protected getHtmlContentPath() : string {
+        return path.join('htmlresources', 'altableextwizard', 'altableextwizard.html');
+    }
+
+    protected getViewType() : string {
+        return "azALDevTools.ALTableExtWizard";
+    }
+
+    protected async finishWizard(data : any) : Promise<boolean> {
+        //build parameters
+        this._tableExtWizardData.objectId = data.objectId;
+        this._tableExtWizardData.objectName = data.objectName;
+        this._tableExtWizardData.fields = WizardTableFieldHelper.validateFields(data.fields);
+        this._tableExtWizardData.selectedTable = data.selectedTable;
+    
+        //build new object
+        var builder : ALTableExtSyntaxBuilder = new ALTableExtSyntaxBuilder();
+        var source = builder.buildFromTableExtWizardData(this._settings.getDestDirectoryUri(), this._tableExtWizardData);
+        this.createObjectExtensionFile('TableExtension', this._tableExtWizardData.objectId, this._tableExtWizardData.objectName, this._tableExtWizardData.selectedTable, source);
+
+        return true;
+    }
+
+    protected processWebViewMessage(message : any) : boolean {
+        if (super.processWebViewMessage(message)) {
+            return true;
+        }
+
+        switch (message.command) {
+            case 'loadTypes':
+                this.loadTypes();
+                return true;
+        }
+        
+        return false;
+    }
+
+    protected async loadTypes() {
+        let types: string[] = await WizardTableFieldHelper.getAllFieldTypes(this._toolsExtensionContext, this._settings.getDestDirectoryUri());
+        // update types
+        if (types.length > 0) {
+            this.sendMessage({
+                command : 'setTypes',
+                data : types
+            });
+        }
+    }
+}

--- a/src/objectwizards/wizards/alTableWizardPage.ts
+++ b/src/objectwizards/wizards/alTableWizardPage.ts
@@ -5,8 +5,8 @@ import { ProjectItemWizardPage } from './projectItemWizardPage';
 import { DevToolsExtensionContext } from '../../devToolsExtensionContext';
 import { ALTableWizardData } from './alTableWizardData';
 import { ALObjectWizardSettings } from './alObjectWizardSettings';
-import { ALTableWizardFieldData } from './alTableWizardFieldData';
 import { ALTableSyntaxBuilder } from '../syntaxbuilders/alTableSyntaxBuilder';
+import { WizardTableFieldHelper } from './wizardTableFieldHelper';
 
 export class ALTableWizardPage extends ProjectItemWizardPage {
     private _tableWizardData : ALTableWizardData;
@@ -39,7 +39,7 @@ export class ALTableWizardPage extends ProjectItemWizardPage {
         //build parameters
         this._tableWizardData.objectId = data.objectId;
         this._tableWizardData.objectName = data.objectName;
-        this._tableWizardData.fields = this.validateFields(data.fields);
+        this._tableWizardData.fields = WizardTableFieldHelper.validateFields(data.fields);
     
         //build new object
         var builder : ALTableSyntaxBuilder = new ALTableSyntaxBuilder();
@@ -49,35 +49,14 @@ export class ALTableWizardPage extends ProjectItemWizardPage {
         return true;
     }
 
-    protected validateFields(data : any) : ALTableWizardFieldData[] {
-        let fields : ALTableWizardFieldData[] = [];
-
-        if ((data) && (data.length > 0)) {
-            for (let i = 0; i<data.length; i++) {
-                fields.push(new ALTableWizardFieldData(data[i].id, data[i].name, data[i].dataType, data[i].length, data[i].dataClassification));
-            }
-        }
-
-
-        return fields;
-    }
-
     protected async loadTypes() {
-        let enumsList = await this._toolsExtensionContext.alLangProxy.getEnumList(this._settings.getDestDirectoryUri());
-        //update types
-        if (enumsList.length > 0) {
-            let types: string[] = ['Blob', 'Boolean', 'Code', 'Date', 'DateFormula', 'DateTime', 'Decimal', 'Duration',
-                'Guid', 'Integer', 'Media', 'MediaSet', 'Option', 'RecordId', 'TableFilter',
-                'Text', 'Time'];
-
-            for (let i=0; i<enumsList.length; i++)
-                types.push('Enum ' + enumsList[i]);
-                
+        let types: string[] = await WizardTableFieldHelper.getAllFieldTypes(this._toolsExtensionContext, this._settings.getDestDirectoryUri());
+        // update types
+        if (types.length > 0) {
             this.sendMessage({
                 command : 'setTypes',
                 data : types
             });
         }
     }
-
 }

--- a/src/objectwizards/wizards/wizardTableFieldHelper.ts
+++ b/src/objectwizards/wizards/wizardTableFieldHelper.ts
@@ -1,0 +1,35 @@
+import { ALTableWizardFieldData } from "./alTableWizardFieldData";
+import { DevToolsExtensionContext } from "../../devToolsExtensionContext";
+import { Uri } from "vscode";
+
+export class WizardTableFieldHelper {
+    public static async getAllFieldTypes(extensionContext: DevToolsExtensionContext, resourceUri: Uri | undefined): Promise<string[]> {
+        let types: string[] = ['Blob', 'Boolean', 'Code', 'Date', 'DateFormula', 'DateTime', 'Decimal', 'Duration',
+            'Guid', 'Integer', 'Media', 'MediaSet', 'Option', 'RecordId', 'TableFilter',
+            'Text', 'Time'];
+
+        let enumList: string[] = await extensionContext.alLangProxy.getEnumList(resourceUri);
+        if (enumList.length > 0) {
+            for (let i = 0; i < enumList.length; i++) {
+                types.push('Enum ' + enumList[i]);
+            }
+        }
+        else {
+            types.push('Enum');
+        }
+            
+        return types;
+    }
+
+    public static validateFields(data : any) : ALTableWizardFieldData[] {
+        let fields : ALTableWizardFieldData[] = [];
+    
+        if ((data) && (data.length > 0)) {
+            for (let i = 0; i < data.length; i++) {
+                fields.push(new ALTableWizardFieldData(data[i].id, data[i].name, data[i].dataType, data[i].length, data[i].dataClassification));
+            }
+        }
+    
+        return fields;
+    }
+}

--- a/src/services/alObjectWizardsService.ts
+++ b/src/services/alObjectWizardsService.ts
@@ -13,6 +13,7 @@ import { ALObjectWizardSettings } from '../objectwizards/wizards/alObjectWizardS
 import { ALTableWizard } from '../objectwizards/wizards/alTableWizard';
 import { ALCodeunitWizard } from '../objectwizards/wizards/alCodeunitWizard';
 import { ALInterfaceWizard } from '../objectwizards/wizards/alInterfaceWizard';
+import { ALTableExtWizard } from '../objectwizards/wizards/alTableExtWizard';
 
 export class ALObjectWizardsService {
     protected _context: DevToolsExtensionContext;
@@ -24,6 +25,7 @@ export class ALObjectWizardsService {
         //create list of wizards
         this._wizards = [];
         this._wizards.push(new ALTableWizard(context, 'Table', 'New AL Table Wizard', 'Allows to select table name and enter list of fields'));
+        this._wizards.push(new ALTableExtWizard(context, 'Table Extension', 'New Table Extension Wizard', 'Allows to add list of fields to existing table'));
         this._wizards.push(new ALPageWizard(context, 'Page', 'New AL Page Wizard', 'Allows to select page type, fast tabs, source table and fields.'));
         
         this._wizards.push(new ALCodeunitWizard(context, 'Codeunit', 'New AL Codeunit Wizard', 'Allows to create simple codeunits and interface implementations'));

--- a/src/services/alObjectWizardsService.ts
+++ b/src/services/alObjectWizardsService.ts
@@ -25,7 +25,7 @@ export class ALObjectWizardsService {
         //create list of wizards
         this._wizards = [];
         this._wizards.push(new ALTableWizard(context, 'Table', 'New AL Table Wizard', 'Allows to select table name and enter list of fields'));
-        this._wizards.push(new ALTableExtWizard(context, 'Table Extension', 'New Table Extension Wizard', 'Allows to add list of fields to existing table'));
+        this._wizards.push(new ALTableExtWizard(context, 'Table Extension', 'New AL Table Extension Wizard', 'Allows to add list of fields to existing table'));
         this._wizards.push(new ALPageWizard(context, 'Page', 'New AL Page Wizard', 'Allows to select page type, fast tabs, source table and fields.'));
         
         this._wizards.push(new ALCodeunitWizard(context, 'Codeunit', 'New AL Codeunit Wizard', 'Allows to create simple codeunits and interface implementations'));


### PR DESCRIPTION
Hi @anzwdev,
This PR adds a new "Table Extension" wizard as one of the options of the "New AL File Wizard" command.

![New Table Extension Wizard](https://user-images.githubusercontent.com/7383241/86633854-73cb6100-bfd1-11ea-995d-7f0d43ba4ef4.png)

* Reuses the implementations from the TableBasedObjectWizard base-classes (e.g., for loading available tables)
* Reuses the table fields grid of the TableObjectWizard class
* Reuses the implementation for loading field types and validating fields from the TableObjectWizard class

Notable changes:
* The definition of the table fields grid has been moved to a separate file `tablefieldsgridview.js`, which is used by the Table Object Wizard and Table Extension Object Wizard.
* Helper functions concerning table field have been moved to `wizardTableFieldHelper.ts`.
  * The `loadTypes` function has a slightly different implementation as it now uses the `WizardTableFieldHelper.getAllFieldTypes` function, which gets all field types and also still _attempts_ to get all enum types. If no enum types can be found this function falls back to adding `Enum` as a field type. The `loadTypes` function will always send a `setTypes` message to the webview.

Next step is to add a "Page Extension" wizard 😉.

Please let me know what you think and/or if you have any suggestions.