### PR TITLE
Add end-quote for return var name in doc. comment

### DIFF
--- a/src/editorextensions/alDocCommentsProvider.ts
+++ b/src/editorextensions/alDocCommentsProvider.ts
@@ -51,7 +51,7 @@ export class ALDocCommentsProvider implements vscode.CompletionItemProvider {
                                 if (retName.length > 0)
                                     documentationText = documentationText + '\n/// <returns name="' +
                                         XmlHelper.EncodeXmlAttributeValue(retName) + 
-                                        '>$' + snippetParamIdx.toString() + '</returns>';
+                                        '">$' + snippetParamIdx.toString() + '</returns>';
                                 else
                                     documentationText = documentationText + '\n/// <returns>$' + snippetParamIdx.toString() + '</returns>';
                             }


### PR DESCRIPTION
Hi @anzwdev,
This PR should resolve the bug reported in issue #149, i.e., concerning the missing " for the `name` attribute of the `returns`-node in a documentation comment generated for a procedure with a named return value.