### PR TITLE
New Page Extension Wizard (Initial Version)

### DIFF
--- a/htmlresources/alpageextwizard/alpageextwizard.html
+++ b/htmlresources/alpageextwizard/alpageextwizard.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ##CSPSOURCE## https: data:; script-src ##CSPSOURCE## 'unsafe-eval'; style-src ##CSPSOURCE##; font-src ##CSPSOURCE##;" />
+        <script src="##EXTENSIONPATH##/htmlresources/lib/jquery/jquery.min.js"></script>
+        <script src="##EXTENSIONPATH##/htmlresources/lib/jquery-ui/jquery-ui.min.js"></script>
+        <script src="##EXTENSIONPATH##/htmlresources/lib/autocomplete/autocomplete.js"></script>
+        <script src="##EXTENSIONPATH##/htmlresources/lib/helpers/htmlhelper.js"></script>
+        <script src="##EXTENSIONPATH##/htmlresources/lib/filteredlist/filteredlist.js"></script>
+        <script src="##EXTENSIONPATH##/htmlresources/alpageextwizard/js/alpageextwizard.js"></script>
+        <link rel="stylesheet" type="text/css" href="##EXTENSIONPATH##/htmlresources/lib/jquery-ui/jquery-ui.min.css">
+        <link rel="stylesheet" type="text/css" href="##EXTENSIONPATH##/htmlresources/lib/autocomplete/autocomplete.css">
+        <link rel="stylesheet" type="text/css" href="##EXTENSIONPATH##/htmlresources/lib/wizards/wizards.css">
+        <link rel="stylesheet" type="text/css" href="##EXTENSIONPATH##/htmlresources/alpageextwizard/css/alpageextwizard.css">
+    </head>
+    <body>
+        <div id="main" class="main">
+            <div id="header" class="header">
+                <div class="title">New Page Extension Wizard</div>
+            </div>
+
+            <div id="wizardstep1" class="wizard">
+
+                <div class="formline">
+                    <div class="formheader">Please enter page extension properties.</div>
+                </div>
+                        
+                <div class="formline">
+                    <div class="formcaption">Object Id:</div>
+                    <div class="formfield">
+                        <input type="text" id="objectid" name="objectid" class="fixedtext">
+                    </div>
+                </div>
+        
+                <div class="formline">
+                    <div class="formcaption">Object Name:</div>
+                    <div class="formfield">
+                        <input type="text" id="objectname" name="objectname" class="fulltext">
+                    </div>
+                </div>
+    
+                <div class="formline">
+                    <div class="formcaption">Extends:</div>
+                    <div class="formfield">
+                        <input type="text" id="basepage" name="basepage" class="fulltext" />
+                    </div>
+                </div>
+                
+            </div>
+
+            <div id="footer" class="footer">
+                <button id="prevBtn" class="button">Previous</button>
+                <button id="nextBtn" class="button">Next</button>
+                <button id="finishBtn" class="button">Finish</button>
+                <button id="cancelBtn" class="button">Cancel</button>
+            </div>
+        </div>
+
+    </body>
+</html>

--- a/htmlresources/alpageextwizard/css/alpageextwizard.css
+++ b/htmlresources/alpageextwizard/css/alpageextwizard.css
@@ -1,0 +1,6 @@
+.fttab {
+    display: block;
+    margin: 0;
+    padding: 4px;
+    border: 1px solid #303030;
+}

--- a/htmlresources/alpageextwizard/js/alpageextwizard.js
+++ b/htmlresources/alpageextwizard/js/alpageextwizard.js
@@ -1,0 +1,166 @@
+class PageExtWizard {
+
+    constructor() {
+        this._step = 1;
+        this._vscode = acquireVsCodeApi();
+
+        // Handle messages sent from the extension to the webview
+        window.addEventListener('message', event => {
+            this.onMessage(event.data);
+        });
+
+        document.getElementById('finishBtn').addEventListener('click', event => {
+            this.onFinish();
+        });
+
+        document.getElementById('cancelBtn').addEventListener('click', event => {
+            this.onCancel();
+        });      
+
+        this.sendMessage({
+            command: 'documentLoaded'
+        });
+    }
+
+    updateMainButtons() {
+        document.getElementById("prevBtn").disabled = true;
+        document.getElementById("nextBtn").disabled = true;
+    }
+
+    updateControls() {
+        this.updateMainButtons();
+    }
+
+    onMessage(message) {     
+        switch (message.command) {
+            case 'setData':
+                this.setData(message.data);
+                break;
+            case 'setPages':
+                this.setPages(message.data);
+                break;
+        }
+    }
+
+    sendMessage(data) {
+        this._vscode.postMessage(data);    
+    }
+
+    setData(data) {
+        this._data = data;        
+       
+        if (this._data) {
+            //initialize inputs
+            document.getElementById("objectid").value = this._data.objectId;
+            document.getElementById("objectname").value = this._data.objectName;
+            document.getElementById("basepage").value = this._data.basePage;
+            
+            this.updateControls();
+        }
+
+    }
+
+    setPages(data) {
+        if (!this._data) {
+            this._data = {};
+        }
+        this._data.pageList = data;        
+        this.loadPages();
+    }
+
+    loadPages() {
+        if (this._data) {
+            this.initPageAutoComplete();
+        }
+    }
+
+    initPageAutoComplete() {
+        let me = this;
+        let allowedChars = new RegExp(/^[a-zA-Z\s]+$/);
+
+        autocomplete({
+			input: document.getElementById('basepage'),
+			minLength: 1,
+			onSelect: function (item, inputfield) {
+				inputfield.value = item;
+			},
+			fetch: function (text, callback) {
+				let match = text.toLowerCase();
+				callback(me._data.pageList.filter(function(n) { return n.toLowerCase().indexOf(match) !== -1; }));
+			},
+			render: function(item, value) {
+				let itemElement = document.createElement("div");
+				if (allowedChars.test(value)) {
+					let regex = new RegExp(value, 'gi');
+					let inner = item.replace(regex, function(match) { return "<strong>" + match + "</strong>"; });
+					itemElement.innerHTML = inner;
+				} else {
+					itemElement.textContent = item;
+				}
+				return itemElement;
+			},
+			emptyMsg: "No pages found",
+			customize: function(input, inputRect, container, maxHeight) {
+				if (maxHeight < 100) {
+					container.style.top = "";
+					container.style.bottom = (window.innerHeight - inputRect.bottom + input.offsetHeight) + "px";
+					container.style.maxHeight = "140px";
+				}
+			}
+		});
+    }
+   
+    onFinish() {
+        this.collectStepData(true);
+
+        if (!this.canFinish()) {
+            return;
+        }
+            
+        this.sendMessage({
+            command: "finishClick",
+            data: {
+                objectId : this._data.objectId,
+                objectName : this._data.objectName,
+                basePage : this._data.basePage,
+            }
+        });
+    }
+
+    onCancel() {
+        this.sendMessage({
+            command : "cancelClick"
+        });
+    }
+
+    collectStepData(finishSelected) {
+        this._data.objectId = document.getElementById("objectid").value;
+        this._data.objectName = document.getElementById("objectname").value;
+        this._data.basePage = document.getElementById("basepage").value;
+    }
+
+    canFinish() {
+        if ((!this._data.objectName) || (this._data.objectName == '')) {
+            this.sendMessage({
+                command: 'showError',
+                message: 'Please enter object name.'
+            });
+            return false;
+        }
+
+        if ((!this._data.basePage) || (this._data.basePage == '')) {
+            this.sendMessage({
+                command: 'showError',
+                message: 'Please enter a target object name.'
+            });
+            return false;
+        }
+        return true;
+    }
+}
+
+var wizard;
+
+window.onload = function() {
+    wizard = new PageExtWizard();
+};

--- a/src/allanguage/alLangServerProxy.ts
+++ b/src/allanguage/alLangServerProxy.ts
@@ -285,6 +285,17 @@ export class ALLangServerProxy {
         return "";
     }
 
+    async getPageList(resourceUri: vscode.Uri | undefined) : Promise<string[]> {
+        let fileContent = "page 0 _symbolcache\n{\nprocedure t()\nvar\nf:page ;\nbegin\nend;\n}";
+        let list = await this.getCompletionForSourceCode(resourceUri, "Loading list of tables.", fileContent,
+            4, 7, 7, 1);
+
+        //process results
+        if (list)
+            return this.getSymbolLabels(list, vscode.CompletionItemKind.Class);
+        return [];
+    }
+
     async getTableList(resourceUri: vscode.Uri | undefined) : Promise<string[]> {
         let fileContent = "codeunit 0 _symbolcache\n{\nprocedure t()\nvar\nf:record ;\nbegin\nend;\n}";
         let list = await this.getCompletionForSourceCode(resourceUri, "Loading list of tables.", fileContent,

--- a/src/objectwizards/syntaxbuilders/alPageExtSyntaxBuilder.ts
+++ b/src/objectwizards/syntaxbuilders/alPageExtSyntaxBuilder.ts
@@ -1,0 +1,19 @@
+import * as vscode from 'vscode';
+import { ALSyntaxWriter } from "../../allanguage/alSyntaxWriter";
+import { ALPageExtWizardData } from '../wizards/alPageExtWizardData';
+
+export class ALPageExtSyntaxBuilder {
+    constructor() {
+    }
+
+    buildFromPageExtWizardData(destUri: vscode.Uri | undefined, data: ALPageExtWizardData) : string {
+        //generate file content
+        let writer : ALSyntaxWriter = new ALSyntaxWriter(destUri);
+
+        writer.writeStartExtensionObject("pageextension", data.objectId, data.objectName, data.basePage);
+
+        writer.writeEndObject();
+
+        return writer.toString();
+    }
+}

--- a/src/objectwizards/wizards/alPageExtWizard.ts
+++ b/src/objectwizards/wizards/alPageExtWizard.ts
@@ -1,0 +1,29 @@
+import { ALObjectWizard } from "./alObjectWizard";
+import { DevToolsExtensionContext } from "../../devToolsExtensionContext";
+import { ALObjectWizardSettings } from "./alObjectWizardSettings";
+import { ALPageExtWizardPage } from "./alPageExtWizardPage";
+import { ALPageExtWizardData } from "./alPageExtWizardData";
+
+export class ALPageExtWizard extends ALObjectWizard {
+
+    constructor(toolsExtensionContext : DevToolsExtensionContext, newLabel: string, newDescription : string, newDetails: string) {
+        super(toolsExtensionContext, newLabel, newDescription, newDetails);
+    }
+
+    run(settings: ALObjectWizardSettings) {
+        super.run(settings);
+        this.runAsync(settings);
+    }
+
+    protected async runAsync(settings: ALObjectWizardSettings) {
+        let objectId : string = await this._toolsExtensionContext.alLangProxy.getNextObjectId(settings.getDestDirectoryUri(), "pageextension");
+
+        let wizardData : ALPageExtWizardData = new ALPageExtWizardData();
+        wizardData.objectId = objectId;
+        wizardData.objectName = '';
+        wizardData.basePage = '';
+        let wizardPage : ALPageExtWizardPage = new ALPageExtWizardPage(this._toolsExtensionContext, settings, wizardData);
+        wizardPage.show();
+    }
+
+}

--- a/src/objectwizards/wizards/alPageExtWizardData.ts
+++ b/src/objectwizards/wizards/alPageExtWizardData.ts
@@ -1,0 +1,14 @@
+export class ALPageExtWizardData {
+    objectId : string;
+    objectName : string;
+    pageList : string[] | undefined;
+    basePage: string;
+
+    constructor() {
+        this.objectId = '';
+        this.objectName = '';
+        this.pageList = undefined;
+        this.basePage = "";
+    }
+
+}

--- a/src/objectwizards/wizards/alPageExtWizardPage.ts
+++ b/src/objectwizards/wizards/alPageExtWizardPage.ts
@@ -1,0 +1,74 @@
+import * as path from 'path';
+import { DevToolsExtensionContext } from "../../devToolsExtensionContext";
+import { ALObjectWizardSettings } from "./alObjectWizardSettings";
+import { ALPageExtWizardData } from './alPageExtWizardData';
+import { ALPageExtSyntaxBuilder } from '../syntaxbuilders/alPageExtSyntaxBuilder';
+import { ProjectItemWizardPage } from './projectItemWizardPage';
+
+export class ALPageExtWizardPage extends ProjectItemWizardPage {
+    protected _pageExtWizardData : ALPageExtWizardData;
+
+    constructor(toolsExtensionContext : DevToolsExtensionContext, settings: ALObjectWizardSettings, data : ALPageExtWizardData) {
+        super(toolsExtensionContext, "AL Page Extension Wizard", settings);
+        this._pageExtWizardData = data;
+    }
+
+    //initialize wizard
+    protected onDocumentLoaded() {
+        //send data to the web view
+        this.sendMessage({
+            command : 'setData',
+            data : this._pageExtWizardData
+        });
+        this.loadPages();
+    }
+
+    protected getHtmlContentPath() : string {
+        return path.join('htmlresources', 'alpageextwizard', 'alpageextwizard.html');
+    }
+
+    protected getViewType() : string {
+        return "azALDevTools.ALPageExtWizard";
+    }
+
+    protected processWebViewMessage(message : any) : boolean {
+        if (super.processWebViewMessage(message)) {
+            return true;
+        }
+
+        switch (message.command) {
+            case 'loadPages':
+                this.loadPages();
+                return true;
+        }
+        
+        return false;
+    }
+
+    protected async finishWizard(data : any) : Promise<boolean> {
+        //build parameters
+        this._pageExtWizardData.objectId = data.objectId;
+        this._pageExtWizardData.objectName = data.objectName;
+        this._pageExtWizardData.basePage = data.basePage;
+        
+        //build new object
+        let builder : ALPageExtSyntaxBuilder = new ALPageExtSyntaxBuilder();
+        let source = await builder.buildFromPageExtWizardData(this._settings.getDestDirectoryUri(),
+            this._pageExtWizardData);
+        this.createObjectExtensionFile('PageExtension', this._pageExtWizardData.objectId, this._pageExtWizardData.objectName, this._pageExtWizardData.basePage, source);
+
+        return true;
+    }
+
+    protected async loadPages() {
+        let resourceUri = this._settings.getDestDirectoryUri();
+        this._pageExtWizardData.pageList = await this._toolsExtensionContext.alLangProxy.getPageList(resourceUri);
+        if ((this._pageExtWizardData.pageList) && (this._pageExtWizardData.pageList.length > 0)) {
+            this.sendMessage({
+                command : "setPages",
+                data : this._pageExtWizardData.pageList
+            });
+        }
+    }
+
+}

--- a/src/services/alObjectWizardsService.ts
+++ b/src/services/alObjectWizardsService.ts
@@ -14,6 +14,7 @@ import { ALTableWizard } from '../objectwizards/wizards/alTableWizard';
 import { ALCodeunitWizard } from '../objectwizards/wizards/alCodeunitWizard';
 import { ALInterfaceWizard } from '../objectwizards/wizards/alInterfaceWizard';
 import { ALTableExtWizard } from '../objectwizards/wizards/alTableExtWizard';
+import { ALPageExtWizard } from '../objectwizards/wizards/alPageExtWizard';
 
 export class ALObjectWizardsService {
     protected _context: DevToolsExtensionContext;
@@ -27,7 +28,8 @@ export class ALObjectWizardsService {
         this._wizards.push(new ALTableWizard(context, 'Table', 'New AL Table Wizard', 'Allows to select table name and enter list of fields'));
         this._wizards.push(new ALTableExtWizard(context, 'Table Extension', 'New AL Table Extension Wizard', 'Allows to add list of fields to existing table'));
         this._wizards.push(new ALPageWizard(context, 'Page', 'New AL Page Wizard', 'Allows to select page type, fast tabs, source table and fields.'));
-        
+        this._wizards.push(new ALPageExtWizard(context, 'Page Extension', 'New AL Page Extension Wizard', 'Allows to add layout and action controls to existing page'));
+
         this._wizards.push(new ALCodeunitWizard(context, 'Codeunit', 'New AL Codeunit Wizard', 'Allows to create simple codeunits and interface implementations'));
 
         this._wizards.push(new ALInterfaceWizard(context, 'Interface', 'New AL Interface Wizard', 'Allows to create a new interface and copy public procedures from a codeunit'));


### PR DESCRIPTION
Hi @anzwdev,
This PR adds a new "Page Extension" wizard as one of the options of the "New AL File Wizard" command.

This is an initial and very basic version, which can be extended later with some features for adding fields through `addLast` blocks.
I think this basic version will suffice for now as it already helps with creating files in the same way you can do that with all the other available options of the "New AL File Wizard" command.

Please let me know what you think and/or if you have any suggestions.