### PR TITLE
AL Report Extension File Wizard

### DIFF
--- a/htmlresources/alreportextwizard/alreportextwizard.html
+++ b/htmlresources/alreportextwizard/alreportextwizard.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ##CSPSOURCE## https: data:; script-src ##CSPSOURCE## 'unsafe-eval'; style-src ##CSPSOURCE##; font-src ##CSPSOURCE##;" />
+        <script src="##EXTENSIONPATH##/htmlresources/lib/jquery/jquery.min.js"></script>
+        <script src="##EXTENSIONPATH##/htmlresources/lib/jquery-ui/jquery-ui.min.js"></script>
+        <script src="##EXTENSIONPATH##/htmlresources/lib/autocomplete/autocomplete.js"></script>
+        <script src="##EXTENSIONPATH##/htmlresources/lib/helpers/htmlhelper.js"></script>
+        <script src="##EXTENSIONPATH##/htmlresources/lib/filteredlist/filteredlist.js"></script>
+        <script src="##EXTENSIONPATH##/htmlresources/alreportextwizard/js/alreportextwizard.js"></script>
+        <link rel="stylesheet" type="text/css" href="##EXTENSIONPATH##/htmlresources/lib/jquery-ui/jquery-ui.min.css">
+        <link rel="stylesheet" type="text/css" href="##EXTENSIONPATH##/htmlresources/lib/autocomplete/autocomplete.css">
+        <link rel="stylesheet" type="text/css" href="##EXTENSIONPATH##/htmlresources/lib/wizards/wizards.css">
+        <link rel="stylesheet" type="text/css" href="##EXTENSIONPATH##/htmlresources/alreportextwizard/css/alreportextwizard.css">
+    </head>
+    <body>
+        <div id="main" class="main">
+            <div id="header" class="header">
+                <div class="title">New Report Extension Wizard</div>
+            </div>
+
+            <div id="wizardstep1" class="wizard">
+
+                <div class="formline">
+                    <div class="formheader">Please enter report extension properties.</div>
+                </div>
+                        
+                <div class="formline">
+                    <div class="formcaption">Object Id:</div>
+                    <div class="formfield">
+                        <input type="text" id="objectid" name="objectid" class="fixedtext">
+                    </div>
+                </div>
+        
+                <div class="formline">
+                    <div class="formcaption">Object Name:</div>
+                    <div class="formfield">
+                        <input type="text" id="objectname" name="objectname" class="fulltext">
+                    </div>
+                </div>
+    
+                <div class="formline">
+                    <div class="formcaption">Extends:</div>
+                    <div class="formfield">
+                        <input type="text" id="basereport" name="basereport" class="fulltext" />
+                    </div>
+                </div>
+                
+            </div>
+
+            <div id="footer" class="footer">
+                <button id="prevBtn" class="button">Previous</button>
+                <button id="nextBtn" class="button">Next</button>
+                <button id="finishBtn" class="button">Finish</button>
+                <button id="cancelBtn" class="button">Cancel</button>
+            </div>
+        </div>
+
+    </body>
+</html>

--- a/htmlresources/alreportextwizard/css/alreportextwizard.css
+++ b/htmlresources/alreportextwizard/css/alreportextwizard.css
@@ -1,0 +1,6 @@
+.fttab {
+    display: block;
+    margin: 0;
+    padding: 4px;
+    border: 1px solid #303030;
+}

--- a/htmlresources/alreportextwizard/js/alreportextwizard.js
+++ b/htmlresources/alreportextwizard/js/alreportextwizard.js
@@ -1,0 +1,166 @@
+class ReportExtWizard {
+
+    constructor() {
+        this._step = 1;
+        this._vscode = acquireVsCodeApi();
+
+        // Handle messages sent from the extension to the webview
+        window.addEventListener('message', event => {
+            this.onMessage(event.data);
+        });
+
+        document.getElementById('finishBtn').addEventListener('click', event => {
+            this.onFinish();
+        });
+
+        document.getElementById('cancelBtn').addEventListener('click', event => {
+            this.onCancel();
+        });
+
+        this.sendMessage({
+            command: 'documentLoaded'
+        });
+    }
+
+    updateMainButtons() {
+        document.getElementById("prevBtn").disabled = true;
+        document.getElementById("nextBtn").disabled = true;
+    }
+
+    updateControls() {
+        this.updateMainButtons();
+    }
+
+    onMessage(message) {
+        switch (message.command) {
+            case 'setData':
+                this.setData(message.data);
+                break;
+            case 'setReports':
+                this.setReports(message.data);
+                break;
+        }
+    }
+
+    sendMessage(data) {
+        this._vscode.postMessage(data);
+    }
+
+    setData(data) {
+        this._data = data;
+
+        if (this._data) {
+            //initialize inputs
+            document.getElementById("objectid").value = this._data.objectId;
+            document.getElementById("objectname").value = this._data.objectName;
+            document.getElementById("basereport").value = this._data.baseReport;
+
+            this.updateControls();
+        }
+
+    }
+
+    setReports(data) {
+        if (!this._data) {
+            this._data = {};
+        }
+        this._data.reportList = data;
+        this.loadReports();
+    }
+
+    loadReports() {
+        if (this._data) {
+            this.initReportAutoComplete();
+        }
+    }
+
+    initReportAutoComplete() {
+        let me = this;
+        let allowedChars = new RegExp(/^[a-zA-Z\s]+$/);
+
+        autocomplete({
+			input: document.getElementById('basereport'),
+			minLength: 1,
+			onSelect: function (item, inputfield) {
+				inputfield.value = item;
+			},
+			fetch: function (text, callback) {
+				let match = text.toLowerCase();
+				callback(me._data.reportList.filter(function(n) { return n.toLowerCase().indexOf(match) !== -1; }));
+			},
+			render: function(item, value) {
+				let itemElement = document.createElement("div");
+				if (allowedChars.test(value)) {
+					let regex = new RegExp(value, 'gi');
+					let inner = item.replace(regex, function(match) { return "<strong>" + match + "</strong>"; });
+					itemElement.innerHTML = inner;
+				} else {
+					itemElement.textContent = item;
+				}
+				return itemElement;
+			},
+			emptyMsg: "No reports found",
+			customize: function(input, inputRect, container, maxHeight) {
+				if (maxHeight < 100) {
+					container.style.top = "";
+					container.style.bottom = (window.innerHeight - inputRect.bottom + input.offsetHeight) + "px";
+					container.style.maxHeight = "140px";
+				}
+			}
+		});
+    }
+
+    onFinish() {
+        this.collectStepData(true);
+
+        if (!this.canFinish()) {
+            return;
+        }
+
+        this.sendMessage({
+            command: "finishClick",
+            data: {
+                objectId : this._data.objectId,
+                objectName : this._data.objectName,
+                baseReport : this._data.baseReport,
+            }
+        });
+    }
+
+    onCancel() {
+        this.sendMessage({
+            command : "cancelClick"
+        });
+    }
+
+    collectStepData(finishSelected) {
+        this._data.objectId = document.getElementById("objectid").value;
+        this._data.objectName = document.getElementById("objectname").value;
+        this._data.baseReport = document.getElementById("basereport").value;
+    }
+
+    canFinish() {
+        if ((!this._data.objectName) || (this._data.objectName == '')) {
+            this.sendMessage({
+                command: 'showError',
+                message: 'Please enter object name.'
+            });
+            return false;
+        }
+
+        if ((!this._data.baseReport) || (this._data.baseReport == '')) {
+            this.sendMessage({
+                command: 'showError',
+                message: 'Please enter a target object name.'
+            });
+            return false;
+        }
+        return true;
+    }
+}
+
+var wizard;
+
+window.onload = function() {
+    wizard = new ReportExtWizard();
+};

--- a/src/allanguage/alLangServerProxy.ts
+++ b/src/allanguage/alLangServerProxy.ts
@@ -288,12 +288,23 @@ export class ALLangServerProxy {
 
     async getPageList(resourceUri: vscode.Uri | undefined) : Promise<string[]> {
         let fileContent = "page 0 _symbolcache\n{\nprocedure t()\nvar\nf:page ;\nbegin\nend;\n}";
-        let list = await this.getCompletionForSourceCode(resourceUri, "Loading list of tables.", fileContent,
+        let list = await this.getCompletionForSourceCode(resourceUri, "Loading list of pages.", fileContent,
             4, 7, 7, 1);
 
         //process results
         if (list)
             return this.getSymbolLabels(list, vscode.CompletionItemKind.Class);
+        return [];
+    }
+
+    async getReportList(resourceUri: vscode.Uri | undefined) : Promise<string[]> {
+        let fileContent = "codeunit 0 _symbolcache\n{\nprocedure t()\nvar\nf:report ;\nbegin\nend;\n}";
+        let list = await this.getCompletionForSourceCode(resourceUri, "Loading list of reports.", fileContent,
+            4, 9, 7, 1);
+
+        //process results
+        if (list)
+            return this.getSymbolLabels(list, vscode.CompletionItemKind.Reference);
         return [];
     }
 

--- a/src/objectwizards/syntaxbuilders/alReportExtSyntaxBuilder.ts
+++ b/src/objectwizards/syntaxbuilders/alReportExtSyntaxBuilder.ts
@@ -1,0 +1,19 @@
+import * as vscode from 'vscode';
+import { ALSyntaxWriter } from "../../allanguage/alSyntaxWriter";
+import { ALReportExtWizardData } from '../wizards/alReportExtWizardData';
+
+export class ALReportExtSyntaxBuilder {
+    constructor() {
+    }
+
+    buildFromReportExtWizardData(destUri: vscode.Uri | undefined, data: ALReportExtWizardData) : string {
+        //generate file content
+        let writer : ALSyntaxWriter = new ALSyntaxWriter(destUri);
+
+        writer.writeStartExtensionObject("reportextension", data.objectId, data.objectName, data.baseReport);
+
+        writer.writeEndObject();
+
+        return writer.toString();
+    }
+}

--- a/src/objectwizards/wizards/alReportExtWizard.ts
+++ b/src/objectwizards/wizards/alReportExtWizard.ts
@@ -1,0 +1,30 @@
+import { ALObjectWizard } from "./alObjectWizard";
+import { DevToolsExtensionContext } from "../../devToolsExtensionContext";
+import { ALObjectWizardSettings } from "./alObjectWizardSettings";
+import { ALReportExtWizardPage } from "./alReportExtWizardPage";
+import { ALReportExtWizardData } from "./alReportExtWizardData";
+
+export class ALReportExtWizard extends ALObjectWizard {
+
+    constructor(toolsExtensionContext : DevToolsExtensionContext, newLabel: string, newDescription : string, newDetails: string) {
+        super(toolsExtensionContext, newLabel, newDescription, newDetails);
+    }
+
+    run(settings: ALObjectWizardSettings) {
+        super.run(settings);
+        this.runAsync(settings);
+    }
+
+    protected async runAsync(settings: ALObjectWizardSettings) {
+        // Currently there is a bug in the AL compiler: https://github.com/microsoft/AL/issues/6689
+        let objectId : string = await this._toolsExtensionContext.alLangProxy.getNextObjectId(settings.getDestDirectoryUri(), "reportextension");
+
+        let wizardData : ALReportExtWizardData = new ALReportExtWizardData();
+        wizardData.objectId = objectId;
+        wizardData.objectName = '';
+        wizardData.baseReport = '';
+        let wizardPage : ALReportExtWizardPage = new ALReportExtWizardPage(this._toolsExtensionContext, settings, wizardData);
+        wizardPage.show();
+    }
+
+}

--- a/src/objectwizards/wizards/alReportExtWizardData.ts
+++ b/src/objectwizards/wizards/alReportExtWizardData.ts
@@ -1,0 +1,13 @@
+export class ALReportExtWizardData {
+    objectId : string;
+    objectName : string;
+    reportList : string[] | undefined;
+    baseReport: string;
+
+    constructor() {
+        this.objectId = '';
+        this.objectName = '';
+        this.reportList = undefined;
+        this.baseReport = "";
+    }
+}

--- a/src/objectwizards/wizards/alReportExtWizardPage.ts
+++ b/src/objectwizards/wizards/alReportExtWizardPage.ts
@@ -1,0 +1,74 @@
+import * as path from 'path';
+import { DevToolsExtensionContext } from "../../devToolsExtensionContext";
+import { ALObjectWizardSettings } from "./alObjectWizardSettings";
+import { ALReportExtWizardData } from './alReportExtWizardData';
+import { ALReportExtSyntaxBuilder } from '../syntaxbuilders/alReportExtSyntaxBuilder';
+import { ProjectItemWizardPage } from './projectItemWizardPage';
+
+export class ALReportExtWizardPage extends ProjectItemWizardPage {
+    protected _reportExtWizardData : ALReportExtWizardData;
+
+    constructor(toolsExtensionContext : DevToolsExtensionContext, settings: ALObjectWizardSettings, data : ALReportExtWizardData) {
+        super(toolsExtensionContext, "AL Report Extension Wizard", settings);
+        this._reportExtWizardData = data;
+    }
+
+    //initialize wizard
+    protected onDocumentLoaded() {
+        //send data to the web view
+        this.sendMessage({
+            command : 'setData',
+            data : this._reportExtWizardData
+        });
+        this.loadReports();
+    }
+
+    protected getHtmlContentPath() : string {
+        return path.join('htmlresources', 'alreportextwizard', 'alreportextwizard.html');
+    }
+
+    protected getViewType() : string {
+        return "azALDevTools.ALReportExtWizard";
+    }
+
+    protected processWebViewMessage(message : any) : boolean {
+        if (super.processWebViewMessage(message)) {
+            return true;
+        }
+
+        switch (message.command) {
+            case 'loadReports':
+                this.loadReports();
+                return true;
+        }
+
+        return false;
+    }
+
+    protected async finishWizard(data : any) : Promise<boolean> {
+        //build parameters
+        this._reportExtWizardData.objectId = data.objectId;
+        this._reportExtWizardData.objectName = data.objectName;
+        this._reportExtWizardData.baseReport = data.baseReport;
+
+        //build new object
+        let builder : ALReportExtSyntaxBuilder = new ALReportExtSyntaxBuilder();
+        let source = await builder.buildFromReportExtWizardData(this._settings.getDestDirectoryUri(),
+            this._reportExtWizardData);
+        this.createObjectExtensionFile('ReportExtension', this._reportExtWizardData.objectId, this._reportExtWizardData.objectName, this._reportExtWizardData.baseReport, source);
+
+        return true;
+    }
+
+    protected async loadReports() {
+        let resourceUri = this._settings.getDestDirectoryUri();
+        this._reportExtWizardData.reportList = await this._toolsExtensionContext.alLangProxy.getReportList(resourceUri);
+        if ((this._reportExtWizardData.reportList) && (this._reportExtWizardData.reportList.length > 0)) {
+            this.sendMessage({
+                command : "setReports",
+                data : this._reportExtWizardData.reportList
+            });
+        }
+    }
+
+}

--- a/src/services/alObjectWizardsService.ts
+++ b/src/services/alObjectWizardsService.ts
@@ -15,6 +15,7 @@ import { ALCodeunitWizard } from '../objectwizards/wizards/alCodeunitWizard';
 import { ALInterfaceWizard } from '../objectwizards/wizards/alInterfaceWizard';
 import { ALTableExtWizard } from '../objectwizards/wizards/alTableExtWizard';
 import { ALPageExtWizard } from '../objectwizards/wizards/alPageExtWizard';
+import { ALReportExtWizard } from '../objectwizards/wizards/alReportExtWizard';
 import { DevToolsExtensionService } from './devToolsExtensionService';
 
 export class ALObjectWizardsService extends DevToolsExtensionService {
@@ -36,6 +37,7 @@ export class ALObjectWizardsService extends DevToolsExtensionService {
 
         this._wizards.push(new ALXmlPortWizard(context, 'XmlPort', 'New AL XmlPort Wizard', 'Allows to select source table and fields'));
         this._wizards.push(new ALReportWizard(context, 'Report', 'New AL Report Wizard', 'Allows to select source table and fields'));
+        this._wizards.push(new ALReportExtWizard(context, 'Report Extension', 'New AL Report Extension Wizard', 'Allows to add dataitems and columns to existing reports'));
         this._wizards.push(new ALQueryWizard(context, 'Query', 'New AL Query Wizard', 'Allows to select query type, source table and fields'));
         this._wizards.push(new ALEnumWizard(context, 'Enum', 'New AL Enum Wizard', 'Allows to select list of enum values and captions'));
         this._wizards.push(new ALEnumExtWizard(context, 'Enum Extension', 'New AL Enum Extension Wizard', 'Allows to add list of enum values and captions to existing enum'));        


### PR DESCRIPTION
Hi @anzwdev,

This PR adds a new "Report Extension" wizard as one of the options of the "New AL File Wizard" command.

![al-report-ext-file-wizard](https://user-images.githubusercontent.com/7383241/127615737-ab61a8ff-b6aa-4c5c-a486-d091acc6e29a.png)

This is an initial and very basic version, which can be extended later.
I think this basic version will suffice for now as it already helps with creating files in the same way you can do that with all the other available options of the "New AL File Wizard" command.

Known issue: https://github.com/microsoft/AL/issues/6689
Currently there is a bug in the AL compiler, so retrieving the next free object ID does not work for report extension objects (as AL Code Outline/AZ AL Dev Tools uses this same feature).

Please let me know what you think and/or if you have any suggestions.