### PR TITLE
Report Extension Symbols-based Object Wizard

### DIFF
--- a/htmlresources/alsymbolsbrowser/js/symbolsbrowser.js
+++ b/htmlresources/alsymbolsbrowser/js/symbolsbrowser.js
@@ -153,6 +153,11 @@ class ObjectBrowser {
                     disabled: function(key, opt) {
                         return (Number($(this).data("kind")) != ALSymbolKind.PageObject);
                     }},
+                "extendreport": {
+                    name: "New Report Extension",
+                    disabled: function(key, opt) {
+                        return (Number($(this).data("kind")) != ALSymbolKind.ReportObject);
+                    }},
                 "sep4": "---------",
                 "expandcollapse": {name: "Expand/collapse child nodes"},
                 }

--- a/htmlresources/objectbrowser/js/objectbrowser.js
+++ b/htmlresources/objectbrowser/js/objectbrowser.js
@@ -319,6 +319,11 @@ class ObjectBrowser {
                         disabled: function(key, opt) {
                          return ($(this).data("objt") != "Page");
                         }},
+                    "extendreport": {
+                        name: "New Report Extension",
+                        disabled: function(key, opt) {
+                            return ($(this).data("objt") != "Report");
+                        }},
                     "sep4": "---------",
                     "copysel": {
                         name: "Copy Selected"

--- a/src/allanguage/alSyntaxWriter.ts
+++ b/src/allanguage/alSyntaxWriter.ts
@@ -151,6 +151,24 @@ export class ALSyntaxWriter {
         this.writeEndBlock();
     }
 
+    public writeStartDataset() {
+        this.writeLine("dataset");
+        this.writeStartBlock();
+    }
+
+    public writeEndDataset() {
+        this.writeEndBlock();
+    }
+
+    public writeStartRequestPage() {
+        this.writeLine("requestpage");
+        this.writeStartBlock();
+    }
+
+    public writeEndRequestPage() {
+        this.writeEndBlock();
+    }
+
     public writeStartFields() {
         this.writeLine("fields");
         this.writeStartBlock();

--- a/src/alsymbolsbrowser/alSymbolsBrowser.ts
+++ b/src/alsymbolsbrowser/alSymbolsBrowser.ts
@@ -11,6 +11,7 @@ import { ALSymbolsBasedQueryWizard } from '../objectwizards/symbolwizards/alSymb
 import { ALSymbolsBasedReportWizard } from '../objectwizards/symbolwizards/alSymbolsBasedReportWizard';
 import { ALSymbolsBasedXmlPortWizard } from '../objectwizards/symbolwizards/alSymbolsBasedXmlPortWizard';
 import { ALSymbolsBasedPageExtWizard } from '../objectwizards/symbolwizards/alSymbolsBasedPageExtWizard';
+import { ALSymbolsBasedReportExtWizard } from '../objectwizards/symbolwizards/alSymbolsBasedReportExtWizard';
 import { ALSymbolsBasedTableExtWizard } from '../objectwizards/symbolwizards/alSymbolsBasedTableExtWizard';
 import { ALSyntaxHelper } from '../allanguage/alSyntaxHelper';
 import { SymbolsTreeView } from '../symbolstreeview/symbolsTreeView';
@@ -146,6 +147,9 @@ export class ALSymbolsBrowser extends BaseWebViewEditor {
             case 'extendpage':
                 this.createPageExt(message.path, message.selpaths);
                 return true;
+            case 'extendreport':
+                this.createReportExt(message.path, message.selpaths);
+                return true;
             case 'copysel':
                 this.copySelected(message.path, message.selpaths);
                 return true;
@@ -236,6 +240,14 @@ export class ALSymbolsBrowser extends BaseWebViewEditor {
         let symbolList = await this.getObjectsFromPath(selPaths, AZSymbolKind.PageObject);
         if (symbolList) {
             let builder : ALSymbolsBasedPageExtWizard = new ALSymbolsBasedPageExtWizard(this._devToolsContext);
+            builder.showWizard(symbolList);
+        }
+    }
+
+    protected async createReportExt(path : number[] | undefined, selPaths: number[][] | undefined) {
+        let symbolList = await this.getObjectsFromPath(selPaths, AZSymbolKind.ReportObject);
+        if (symbolList) {
+            let builder : ALSymbolsBasedReportExtWizard = new ALSymbolsBasedReportExtWizard(this._devToolsContext);
             builder.showWizard(symbolList);
         }
     }

--- a/src/objectwizards/symbolwizards/alSymbolsBasedReportExtWizard.ts
+++ b/src/objectwizards/symbolwizards/alSymbolsBasedReportExtWizard.ts
@@ -1,0 +1,103 @@
+import * as vscode from 'vscode';
+import { FileBuilder } from '../fileBuilder';
+import { AZSymbolInformation } from '../../symbollibraries/azSymbolInformation';
+import { AZSymbolKind } from '../../symbollibraries/azSymbolKind';
+import { ALSymbolsBasedWizard } from './alSymbolsBasedWizard';
+import { ALSyntaxWriter } from '../../allanguage/alSyntaxWriter';
+import { DevToolsExtensionContext } from '../../devToolsExtensionContext';
+
+export class ALSymbolsBasedReportExtWizard extends ALSymbolsBasedWizard {
+
+    constructor(context: DevToolsExtensionContext) {
+        super(context);
+    }
+
+    //#region Wizards with UI
+
+    async showWizard(symbols: AZSymbolInformation[]) {
+        if (symbols.length == 1)
+            await this.showReportExtWizard(symbols[0]);
+        else
+            await this.showMultiReportExtWizard(symbols);
+    }
+
+    async showMultiReportExtWizard(reportSymbols: AZSymbolInformation[]) {
+        if (!FileBuilder.checkCrsExtensionFileNamePatternRequired() || !FileBuilder.checkCrsExtensionObjectNamePatternRequired(true))
+            return;
+
+        const extObjType : AZSymbolKind = AZSymbolKind.ReportExtensionObject;
+        let relativeFileDir: string | undefined = await this.getRelativeFileDir(extObjType);
+
+        let startObjectId: number = await this.getObjectId(relativeFileDir, "reportextension", "Please enter a starting ID for the report extensions.", 0);
+        if (startObjectId < 0) {
+            return;
+        }
+
+        for (let i = 0; i < reportSymbols.length; i++) {
+            let reportSymbol = reportSymbols[i];
+            let extObjectId: number = startObjectId + i;
+            let extObjectName: string = await FileBuilder.getPatternGeneratedExtensionObjectName(extObjType, extObjectId, reportSymbol);
+
+            await this.createAndShowNewReportExtension(reportSymbol, extObjType, extObjectId, extObjectName, relativeFileDir);
+        }
+    }
+
+    async showReportExtWizard(reportSymbol : AZSymbolInformation) {
+        if (!FileBuilder.checkCrsExtensionFileNamePatternRequired() || !FileBuilder.checkCrsExtensionObjectNamePatternRequired(false))
+            return;
+
+        const extObjType : AZSymbolKind = AZSymbolKind.ReportExtensionObject;
+        let relativeFileDir = await this.getRelativeFileDir(extObjType);
+        
+        let extObjectId : number = await this.getObjectId(relativeFileDir, "reportextension", "Please enter an ID for the report extension.", 0);
+        if (extObjectId < 0) {
+            return;
+        }
+
+        let extObjectName: string | undefined = await FileBuilder.getPatternGeneratedExtensionObjectName(extObjType, extObjectId, reportSymbol);
+        if (!extObjectName)
+            extObjectName = reportSymbol.name + ' Extension';
+        extObjectName = await this.getObjectName("Please enter a name for the report extension.", extObjectName);
+        if (!extObjectName) {
+            return;
+        }
+
+        await this.createAndShowNewReportExtension(reportSymbol, extObjType, extObjectId, extObjectName, relativeFileDir);
+    }
+
+    private async createAndShowNewReportExtension(reportSymbol: AZSymbolInformation, extObjType: AZSymbolKind, extObjectId: number, extObjectName: string, relativeFileDir: string| undefined) {
+        let fileName : string = await FileBuilder.getPatternGeneratedExtensionObjectFileName(extObjType, extObjectId, extObjectName, reportSymbol);
+        this.showNewDocument(this.buildReportExtForReport(reportSymbol, extObjectId, extObjectName), fileName, relativeFileDir);
+    }
+
+    //#endregion
+
+    //#region Report Extension builders
+
+    private buildReportExtForReport(reportSymbol : AZSymbolInformation, objectId : number, extObjectName : string) : string {
+        
+        let writer : ALSyntaxWriter = new ALSyntaxWriter(undefined);
+
+        writer.writeStartExtensionObject("reportextension", objectId.toString(), extObjectName, reportSymbol.name);
+        
+        writer.writeStartDataset();
+
+        writer.writeLine("");
+        
+        writer.writeEndDataset();
+        
+        writer.writeLine("");
+
+        writer.writeStartRequestPage();
+
+        writer.writeLine("");
+
+        writer.writeEndRequestPage();
+
+        writer.writeEndObject();
+        
+        return writer.toString();
+    }
+
+    //#endregion
+}


### PR DESCRIPTION
Hi @anzwdev,

This PR adds a new "Report Extension" symbols-based object wizard for the AL Object Browser.

![report extension symbols wizard](https://user-images.githubusercontent.com/7383241/127682392-135878bf-c1fc-452f-9970-346e345f905c.png)

It has the same setup as for page- and table-extensions.