### PR TITLE
Add possibility to modify wizardData from other extensions before calling and showing the wizard.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
  - Issue #434 - Page layout group(general) has no caption
  - Issue #436 - comment= is not fixed when running "Fix identifiers"
  - Issue #439 - Completion provider for "var" function parameter?
+ - Add possibility to modify wizardData from other extensions before calling and showing the wizard.
 
 Thank you
  - JavierFuentes for asking to leave quotes in issue #302

--- a/src/objectwizards/wizards/alCodeunitWizard.ts
+++ b/src/objectwizards/wizards/alCodeunitWizard.ts
@@ -19,6 +19,7 @@ export class ALCodeunitWizard extends ALObjectWizard {
         let wizardData : ALCodeunitWizardData = new ALCodeunitWizardData();
         this.initObjectIdFields(wizardData, settings, "Codeunit");
         wizardData.objectName = '';//settings.getInputNameVariable();
+        this.onBeforeCreateWizardPage(wizardData);
         let wizardPage : ALCodeunitWizardPage = new ALCodeunitWizardPage(this._toolsExtensionContext, settings, wizardData);
         wizardPage.show();
     }

--- a/src/objectwizards/wizards/alEnumExtWizard.ts
+++ b/src/objectwizards/wizards/alEnumExtWizard.ts
@@ -20,6 +20,7 @@ export class ALEnumExtWizard extends ALObjectWizard {
         this.initObjectIdFields(wizardData, settings, "enumextension");
         wizardData.objectName = '';
         wizardData.firstValueId = this._toolsExtensionContext.alLangProxy.getIdRangeStart(settings.getDestDirectoryUri());
+        this.onBeforeCreateWizardPage(wizardData);
         let wizardPage : ALEnumExtWizardPage = new ALEnumExtWizardPage(this._toolsExtensionContext, settings, wizardData);
         wizardPage.show();
     }

--- a/src/objectwizards/wizards/alEnumWizard.ts
+++ b/src/objectwizards/wizards/alEnumWizard.ts
@@ -21,6 +21,7 @@ export class ALEnumWizard extends ALObjectWizard {
         let wizardData : ALEnumWizardData = new ALEnumWizardData();
         this.initObjectIdFields(wizardData, settings, "enum");
         wizardData.objectName = '';
+        this.onBeforeCreateWizardPage(wizardData);
         let wizardPage : ALEnumWizardPage = new ALEnumWizardPage(this._toolsExtensionContext, settings, wizardData);
         wizardPage.show();
     }

--- a/src/objectwizards/wizards/alInterfaceWizard.ts
+++ b/src/objectwizards/wizards/alInterfaceWizard.ts
@@ -18,6 +18,7 @@ export class ALInterfaceWizard extends ALObjectWizard {
     protected async runAsync(settings: ALObjectWizardSettings) {
         let wizardData : ALInterfaceWizardData = new ALInterfaceWizardData();
         wizardData.objectName = '';//settings.getInputNameVariable();
+        this.onBeforeCreateWizardPage(wizardData);
         let wizardPage : ALInterfaceWizardPage = new ALInterfaceWizardPage(this._toolsExtensionContext, settings, wizardData);
         wizardPage.show();
     }

--- a/src/objectwizards/wizards/alObjectWizard.ts
+++ b/src/objectwizards/wizards/alObjectWizard.ts
@@ -7,6 +7,7 @@ export class ALObjectWizard {
     detail: string;
     label: string;
     protected _toolsExtensionContext : DevToolsExtensionContext;
+    onBeforeCreateWizardPage: (wizardData: ALObjectWizardData) => void = () => {};
     
     constructor(newToolsExtensionContext : DevToolsExtensionContext, newLabel: string, newDescription : string, newDetails: string) {
         this._toolsExtensionContext = newToolsExtensionContext;

--- a/src/objectwizards/wizards/alPageExtWizard.ts
+++ b/src/objectwizards/wizards/alPageExtWizard.ts
@@ -20,6 +20,7 @@ export class ALPageExtWizard extends ALObjectWizard {
         this.initObjectIdFields(wizardData, settings, "pageextension");
         wizardData.objectName = '';
         wizardData.basePage = '';
+        this.onBeforeCreateWizardPage(wizardData);
         let wizardPage : ALPageExtWizardPage = new ALPageExtWizardPage(this._toolsExtensionContext, settings, wizardData);
         wizardPage.show();
     }

--- a/src/objectwizards/wizards/alPageWizard.ts
+++ b/src/objectwizards/wizards/alPageWizard.ts
@@ -33,6 +33,7 @@ export class ALPageWizard extends ALObjectWizard {
         wizardData.apiGroup = StringHelper.defaultIfEmpty(config.get<string>('defaultApiGroup'), wizardData.apiGroup);
         wizardData.apiVersion = StringHelper.defaultIfEmpty(config.get<string>('defaultApiVersion'), wizardData.apiVersion);
 
+        this.onBeforeCreateWizardPage(wizardData);
         let wizardPage : ALPageWizardPage = new ALPageWizardPage(this._toolsExtensionContext, settings, wizardData);
         wizardPage.show();
     }

--- a/src/objectwizards/wizards/alPermissionSetExtensionWizard.ts
+++ b/src/objectwizards/wizards/alPermissionSetExtensionWizard.ts
@@ -18,6 +18,7 @@ export class ALPermissionSetExtensionWizard extends ALObjectWizard {
         let wizardData : ALPermissionSetExtensionWizardData = new ALPermissionSetExtensionWizardData();
         this.initObjectIdFields(wizardData, settings, "permissionsetextension");
         wizardData.objectName = '';
+        this.onBeforeCreateWizardPage(wizardData);
         let wizardPage : ALPermissionSetExtensionWizardPage = new ALPermissionSetExtensionWizardPage(this._toolsExtensionContext, settings, wizardData);
         wizardPage.show();
     }

--- a/src/objectwizards/wizards/alPermissionSetWizard.ts
+++ b/src/objectwizards/wizards/alPermissionSetWizard.ts
@@ -18,6 +18,7 @@ export class ALPermissionSetWizard extends ALObjectWizard {
         let wizardData : ALPermissionSetWizardData = new ALPermissionSetWizardData();
         this.initObjectIdFields(wizardData, settings, "permissionset");
         wizardData.objectName = '';
+        this.onBeforeCreateWizardPage(wizardData);
         let wizardPage : ALPermissionSetWizardPage = new ALPermissionSetWizardPage(this._toolsExtensionContext, undefined, settings, wizardData);
         wizardPage.show();
     }

--- a/src/objectwizards/wizards/alQueryWizard.ts
+++ b/src/objectwizards/wizards/alQueryWizard.ts
@@ -22,6 +22,7 @@ export class ALQueryWizard extends ALObjectWizard {
         let wizardData : ALQueryWizardData = new ALQueryWizardData();
         this.initObjectIdFields(wizardData, settings, "Query");
         wizardData.objectName = '';
+        this.onBeforeCreateWizardPage(wizardData);
         let wizardPage : ALQueryWizardPage = new ALQueryWizardPage(this._toolsExtensionContext, settings, wizardData);
         wizardPage.show();
     }

--- a/src/objectwizards/wizards/alReportExtWizard.ts
+++ b/src/objectwizards/wizards/alReportExtWizard.ts
@@ -20,6 +20,7 @@ export class ALReportExtWizard extends ALObjectWizard {
         this.initObjectIdFields(wizardData, settings, "reportextension");
         wizardData.objectName = '';
         wizardData.baseReport = '';
+        this.onBeforeCreateWizardPage(wizardData);
         let wizardPage : ALReportExtWizardPage = new ALReportExtWizardPage(this._toolsExtensionContext, settings, wizardData);
         wizardPage.show();
     }

--- a/src/objectwizards/wizards/alReportWizard.ts
+++ b/src/objectwizards/wizards/alReportWizard.ts
@@ -26,6 +26,7 @@ export class ALReportWizard extends ALObjectWizard {
         //build relative path
         wizardData.rdlcLayout = '';
 
+        this.onBeforeCreateWizardPage(wizardData);
         let wizardPage : ALReportWizardPage = new ALReportWizardPage(this._toolsExtensionContext, settings, wizardData);
         wizardPage.show();
     }

--- a/src/objectwizards/wizards/alTableExtWizard.ts
+++ b/src/objectwizards/wizards/alTableExtWizard.ts
@@ -25,6 +25,7 @@ export class ALTableExtWizard extends ALObjectWizard {
         wizardData.selectedTable = '';
         wizardData.idRangeStart = 
             this._toolsExtensionContext.alLangProxy.getIdRangeStart(settings.getDestDirectoryUri());
+        this.onBeforeCreateWizardPage(wizardData);
         let wizardPage : ALTableExtWizardPage = new ALTableExtWizardPage(this._toolsExtensionContext, settings, wizardData);
         wizardPage.show();
     }

--- a/src/objectwizards/wizards/alTableWizard.ts
+++ b/src/objectwizards/wizards/alTableWizard.ts
@@ -22,6 +22,7 @@ export class ALTableWizard extends ALObjectWizard {
         let wizardData : ALTableWizardData = new ALTableWizardData();
         this.initObjectIdFields(wizardData, settings, "table");
         wizardData.objectName = '';
+        this.onBeforeCreateWizardPage(wizardData);
         let wizardPage : ALTableWizardPage = new ALTableWizardPage(this._toolsExtensionContext, settings, wizardData);
         wizardPage.show();
     }

--- a/src/objectwizards/wizards/alXmlPortWizard.ts
+++ b/src/objectwizards/wizards/alXmlPortWizard.ts
@@ -21,6 +21,7 @@ export class ALXmlPortWizard extends ALObjectWizard {
         let wizardData : ALXmlPortWizardData = new ALXmlPortWizardData();
         this.initObjectIdFields(wizardData, settings, "XmlPort");
         wizardData.objectName = '';
+        this.onBeforeCreateWizardPage(wizardData);
         let wizardPage : ALXmlPortWizardPage = new ALXmlPortWizardPage(this._toolsExtensionContext, settings, wizardData);
         wizardPage.show();
     }


### PR DESCRIPTION
Hi Andrzej,

I got a request of Rob already last year that in case of a missing enum a wizard should be opened where I'd like to trigger yours. https://github.com/DavidFeldhoff/al-codeactions/issues/150 
I just had a look at it again. In case you would open up your extension a bit I could do this and already inject the object name (and maybe other properties). Is that okay with you? Or would you like to have the code totally inside your repo? Would be fine for me as well. I was mainly experimenting with callbacks and working across other VS Code extensions, so I already reached my learning goal ;)

Best regards from covid quarantine 🙈 👋
David