### PR TITLE
Release of #276, #432, #444, #465 and #467

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## 3.0.46
  - Issue #276 - AL Object ID Ninja wizards integration not always works
+ - Issue #467 - AddMissingParentheses adds parentheses to function references in event subscribers (AL Runtime 11.x)
 
 Thank you
  - SBiernat for reporting problem with task #276
+ - fvet for reporting issue #467
 
 ## 3.0.45
  - Issue #432 - Remove redundant DataClassification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,15 @@
 ## 3.0.46
  - Issue #276 - AL Object ID Ninja wizards integration not always works
  - Issue #432 - Remove Redundant DataClassification removes it from table extension fields
+ - Issue #444 - Completion provider seems to ignore 'internal' objects
  - Issue #465 - Order triggers according to their natural order
  - Issue #467 - AddMissingParentheses adds parentheses to function references in event subscribers (AL Runtime 11.x)
 
 Thank you
  - SBiernat for reporting problem with task #276
  - jwikman for reporting problems with task #432
+ - fvet for reporting issues #444 and #467
  - jhoek for reporting issue #465
- - fvet for reporting issue #467
 
 ## 3.0.45
  - Issue #432 - Remove redundant DataClassification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 3.0.46
+ - Issue #276 - AL Object ID Ninja wizards integration not always works
+
+Thank you
+ - SBiernat for reporting problem with task #276
+
 ## 3.0.45
  - Issue #432 - Remove redundant DataClassification
  - Issue #443 - codeCleanupAction AddApplicationAreas adds Application Area to API Pages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 ## 3.0.46
  - Issue #276 - AL Object ID Ninja wizards integration not always works
  - Issue #467 - AddMissingParentheses adds parentheses to function references in event subscribers (AL Runtime 11.x)
+ - Issue #432 - Remove Redundant DataClassification removes it from table extension fields
 
 Thank you
  - SBiernat for reporting problem with task #276
- - fvet for reporting issue #467
+ - jwikman for reporting problems with task #432
+ - fvet for reporting issue #467 
 
 ## 3.0.45
  - Issue #432 - Remove redundant DataClassification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 ## 3.0.46
  - Issue #276 - AL Object ID Ninja wizards integration not always works
- - Issue #467 - AddMissingParentheses adds parentheses to function references in event subscribers (AL Runtime 11.x)
  - Issue #432 - Remove Redundant DataClassification removes it from table extension fields
+ - Issue #465 - Order triggers according to their natural order
+ - Issue #467 - AddMissingParentheses adds parentheses to function references in event subscribers (AL Runtime 11.x)
 
 Thank you
  - SBiernat for reporting problem with task #276
  - jwikman for reporting problems with task #432
- - fvet for reporting issue #467 
+ - jhoek for reporting issue #465
+ - fvet for reporting issue #467
 
 ## 3.0.45
  - Issue #432 - Remove redundant DataClassification

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ When new objects are created, generators use "CRS AL Language Extension" templat
 Extension adds VS Code editor code actions to some of al elements to help developers modify or insert code quickly. At this these types of actions available:
  - Sorting actions that can sort
   - `Sort table fields` available when cursor is at the first line of table, table extension, fields keyword or table/table extension field. It will sort all fields by the field number. 
-  - `Sort procedures` available when cursor is at the first line of a procedure. This action will sort procedures of the same type (i.e. local) in a natural order
+  - `Sort procedures` available when cursor is at the first line of a procedure. This action will sort procedures and triggers of the same type (i.e. local) in a natural order
   - `Sort data item columns` available when cursor is at report data item, column or first line of the object declaration. This action will sort all columns inside data item in a natural order. If it is invoked from the first line of the object, it will sort columns inside all data items.
   - `Sort properties` available from the first line of any object declaration. It will sort properties of every element declared inside the object.
   - `Sort variables` available from the first line of any object declaration or from "var" keyword of local or global variables section
@@ -174,8 +174,8 @@ Extension adds a few commands that allow to automatically modify al code in the 
 * `Remove StrSubstNo from Error from the Active Project`: removes StrSubstNo from Error method call from the current project
 * `Sort Permissions in the Active Editor`: sorts permissions in the current editor
 * `Sort Permissions in the Active Project`: sorts permissions in the current project
-* `Sort Procedures in the Active Editor`: sorts procedures in the current editor
-* `Sort Procedures in the Active Project`: sorts procedures in the current project
+* `Sort Procedures in the Active Editor`: sorts procedures and triggers (sorting triggers is disabled by default) in the current editor
+* `Sort Procedures in the Active Project`: sorts procedures and triggers (sorting triggers is disabled by default) in the current project
 * `Sort Properties in the Active Editor`: sorts properties in the current editor
 * `Sort Properties in the Active Project`: sorts procedures in the current project
 * `Sort Customizations Property in the Active Editor`: sorts Customizations property values in the current editor
@@ -359,6 +359,49 @@ This extension contributes the following settings:
 * `alOutline.additionalMandatoryAffixesPatterns`: Additional list of name affixes patterns, '?' can be used for matching any character. These values are used to remove affixes from names in code actions, commands and code completion
 * `alOutline.dropDownGroupFieldsNamesPatterns`: array of string patters for table DropDown group fields created by "Add DropDown FieldGroups..." commands, you can use "*" for partial name matching, first found field for each setting entry will be used
 * `alOutline.tableDataCaptionFieldsNamesPatterns`: array of string patters for field names for table DataCaptionFields property created by "Add Table DataCaptionFields..." commands, you can use "*" for partial name matching, first found field for each setting entry will be used
+* `alOutline.triggersSortMode` - defines how "sort procedures" commands are sorting triggers, one of these values can be used:
+  * `None` - triggers won't be sorted, this is the default value
+  * `Name` - triggers will be sorted by name
+  * `NaturalOrder` - trigger will be sorted in the "logical" order (i.e. OnPreDataItem, OnAfterGetRecord, OnPostDataItem)
+* `alOutline.triggersNaturalOrder` - array of objects allowing to override default "natural" triggers order for each al syntax element containing triggers. The "parent" field can contain one of these values: 
+  * "Table", 
+  * "TableExtension", 
+  * "Page", 
+  * "PageExtension",
+  * "RequestPage", 
+  * "RequestPageExtension", 
+  * "Report", 
+  * "ReportExtension", 
+  * "XmlPort", "Codeunit", 
+  * "Query", 
+  * "Field", 
+  * "FieldExtension", 
+  * "PageField", 
+  * "PageFieldExtension", 
+  * "Action", 
+  * "ActionExtension", 
+  * "ReportDataItem", 
+  * "ReportExtensionDataSetModify", 
+  * "XmlPortTableElement", 
+  * "XmlPortFieldElement", 
+  * "XmlPortTextElement", 
+  * "XmlPortFieldAttribute", 
+  * "XmlPortTextAttribute".
+  
+  If syntax element is not specified in this setting, default order will be used. Here is an example for table and table field:
+  
+  ```
+  [
+    {
+      "parent": "Table",
+      "order": [ "OnInsert", "OnModify", "OnDelete", "OnRename" ]
+    },
+    {
+      "parent": "Field",
+      "order": [ "OnValidate", "OnLookup" ]
+    }
+  ]
+  ```
 
 ## Known Issues
 

--- a/language-server/AZALDevToolsTestConsoleApp/Program.cs
+++ b/language-server/AZALDevToolsTestConsoleApp/Program.cs
@@ -71,7 +71,7 @@ namespace AZALDevToolsTestConsoleApp
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\MyTestCU.al";
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\Cod50104.IdentifiersTest.al";
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\Rep50100.MyReport.al";
-            //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\MyTable.al";
+            filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\MyTable.al";
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\PageEmptySectionsTest.al";
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\WithTestsCU.al";
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\CSVXmlPort.al";
@@ -79,7 +79,7 @@ namespace AZALDevToolsTestConsoleApp
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\Pag50105.MyItem3.al";
 
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\Tab50100.T1.al";
-            filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\Cod50100.MyNewcodeunit.al";
+            //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\Cod50100.MyNewcodeunit.al";
 
             string content = FileUtils.SafeReadAllText(filePath);
             Dictionary<string, string> pm = new();
@@ -90,6 +90,9 @@ namespace AZALDevToolsTestConsoleApp
             pm.Add("removeGlobalVariables", "true");
             pm.Add("removeLocalVariables", "true");
             pm.Add("removeLocalMethodParameters", "false");
+
+            pm.Add("triggersSortMode", "NaturalOrder");
+            pm.Add("triggersNaturalOrder", "[]");
 
             //pm.Add("dependencyName0", "Microsoft - System");
             //pm.Add("dependencyName1", "Microsoft - Application");
@@ -102,7 +105,7 @@ namespace AZALDevToolsTestConsoleApp
 
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeUnusedVariables", content, projects[0].folderPath, filePath, null, pm, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("convertObjectIdsToNames", content, projects[0], null, pm);
-            WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("addParentheses", content, projects[0].folderPath, filePath, null, pm, null);
+            //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("addParentheses", content, projects[0].folderPath, filePath, null, pm, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("sortVariables", content, projects[0].folderPath, filePath, null, pm, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeBeginEnd", content, projects[0], filePath, null, pm);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("addToolTips", content, projects[0], filePath, null, pm);
@@ -117,6 +120,7 @@ namespace AZALDevToolsTestConsoleApp
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("addReferencedTablesPermissions", content, projects[0].folderPath, filePath, null, pm, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("generateCSVXmlPortHeaders", content, projects[0].folderPath, filePath, null, pm, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeRedundantDataClassification", content, projects[0].folderPath, filePath, null, pm, null);
+            WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("sortProcedures", content, projects[0].folderPath, filePath, null, pm, null);
 
             ALProject project = host.ALDevToolsServer.Workspace.Projects[0];
 

--- a/language-server/AZALDevToolsTestConsoleApp/Program.cs
+++ b/language-server/AZALDevToolsTestConsoleApp/Program.cs
@@ -78,8 +78,8 @@ namespace AZALDevToolsTestConsoleApp
 
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\Pag50105.MyItem3.al";
 
-            filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\Tab50100.T1.al";
-
+            //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\Tab50100.T1.al";
+            filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\Cod50100.MyNewcodeunit.al";
 
             string content = FileUtils.SafeReadAllText(filePath);
             Dictionary<string, string> pm = new();
@@ -102,7 +102,7 @@ namespace AZALDevToolsTestConsoleApp
 
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeUnusedVariables", content, projects[0].folderPath, filePath, null, pm, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("convertObjectIdsToNames", content, projects[0], null, pm);
-            //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("addParentheses", content, projects[0].folderPath, filePath, null, pm, null);
+            WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("addParentheses", content, projects[0].folderPath, filePath, null, pm, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("sortVariables", content, projects[0].folderPath, filePath, null, pm, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeBeginEnd", content, projects[0], filePath, null, pm);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("addToolTips", content, projects[0], filePath, null, pm);
@@ -116,7 +116,7 @@ namespace AZALDevToolsTestConsoleApp
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("addDropDownFieldGroups", content, projects[0].folderPath, filePath, null, pm, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("addReferencedTablesPermissions", content, projects[0].folderPath, filePath, null, pm, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("generateCSVXmlPortHeaders", content, projects[0].folderPath, filePath, null, pm, null);
-            WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeRedundantDataClassification", content, projects[0].folderPath, filePath, null, pm, null);
+            //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeRedundantDataClassification", content, projects[0].folderPath, filePath, null, pm, null);
 
             ALProject project = host.ALDevToolsServer.Workspace.Projects[0];
 

--- a/language-server/AZALDevToolsTestConsoleApp/Program.cs
+++ b/language-server/AZALDevToolsTestConsoleApp/Program.cs
@@ -124,7 +124,10 @@ namespace AZALDevToolsTestConsoleApp
 
             ALProject project = host.ALDevToolsServer.Workspace.Projects[0];
 
-            
+            var allObj = project.AllSymbols.Tables.GetObjects().ToList();
+
+
+
             PageInformationProvider pageInformationProvider = new PageInformationProvider();
             List<string> toolTipsList = pageInformationProvider.GetPageFieldAvailableToolTips(project, "Page", "MyTestPage", "", "Rec.\"No.\"");
 

--- a/language-server/Shared.AnZwDev.ALTools/ALSymbolReferences/Serialization/NavAppManifestNavxPackageConverter.cs
+++ b/language-server/Shared.AnZwDev.ALTools/ALSymbolReferences/Serialization/NavAppManifestNavxPackageConverter.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿using Microsoft.Dynamics.Nav.CodeAnalysis.Packaging;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace AnZwDev.ALTools.ALSymbolReferences.Serialization
@@ -13,6 +15,7 @@ namespace AnZwDev.ALTools.ALSymbolReferences.Serialization
             package.App = NavAppManifestNavxPackageConverter.CreateNavxApp(navAppManifest);
 #if BC
             package.ResourceExposurePolicy = NavAppManifestNavxPackageConverter.CreateNavxResourceExposurePolicy(navAppManifest.ResourceExposurePolicy);
+            package.InternalsVisibleTo = CreateInternalsVisibleTo(navAppManifest.InternalsVisibleTo);
 #endif
             List<NavxDependency> dependencies = new List<NavxDependency>();
             foreach (Microsoft.Dynamics.Nav.CodeAnalysis.Packaging.NavAppDependency navAppDependency in navAppManifest.Dependencies)
@@ -20,7 +23,25 @@ namespace AnZwDev.ALTools.ALSymbolReferences.Serialization
                 dependencies.Add(NavAppManifestNavxPackageConverter.CreateNavxDependency(navAppDependency));
             }
             package.Dependencies = dependencies.ToArray();
+
             return package;
+        }
+
+        private static NavxModuleReference[] CreateInternalsVisibleTo(IEnumerable<NavAppDependency> navAppInternalsVisibleTo)
+        {
+            if (navAppInternalsVisibleTo == null)
+                return null;
+            List<NavxModuleReference> internalsVisibleTo = new List<NavxModuleReference>();
+            foreach (var navAppInternal in navAppInternalsVisibleTo)
+            {
+                internalsVisibleTo.Add(new NavxModuleReference()
+                {
+                    Id = navAppInternal.AppId.ToString("D").ToLower(),
+                    Name = navAppInternal.Name,
+                    Publisher = navAppInternal.Publisher,
+                });
+            }
+            return internalsVisibleTo.ToArray();
         }
 
         private static Core.VersionNumber CreateVersion(System.Version version)

--- a/language-server/Shared.AnZwDev.ALTools/ALSymbols/Internal/ConvertedSyntaxKind.cs
+++ b/language-server/Shared.AnZwDev.ALTools/ALSymbols/Internal/ConvertedSyntaxKind.cs
@@ -2374,7 +2374,20 @@ namespace AnZwDev.ALTools.ALSymbols.Internal
         BadDirectiveTrivia = 526,
         PragmaWarningDirectiveTrivia = 527,
         PragmaImplicitWithDirectiveTrivia = 528,
-        BadPragmaDirectiveTrivia = 529
-
+        BadPragmaDirectiveTrivia = 529,
+        ActionRefKeyword = 530,
+        ActionsV2Keyword = 531,
+        CustomActionKeyword = 532,
+        IdentifierAttributeArgument = 533,
+        IdentifierOrLiteralOrOptionAccessExpression = 534,
+        InherentEntitlementsPropertyValue = 535,
+        InherentPermissionsPropertyValue = 536,
+        LayoutKeyword = 537,
+        PageActionRef = 538,
+        PageCustomAction = 539,
+        PragmaActionsV2DirectiveTrivia = 540,
+        RenderingKeyword = 541,
+        ReportLayout = 542,
+        ReportRenderingSection = 543
     }
 }

--- a/language-server/Shared.AnZwDev.ALTools/CodeTransformations/DataClassificationSyntaxRewriter.cs
+++ b/language-server/Shared.AnZwDev.ALTools/CodeTransformations/DataClassificationSyntaxRewriter.cs
@@ -46,8 +46,15 @@ namespace AnZwDev.ALTools.CodeTransformations
                     _tableDataClassification = DataClassification;
                 }
             }
+            var tableNode = base.VisitTable(node);
+            _tableDataClassification = null;
+            return tableNode;
+        }
 
-            return base.VisitTable(node);
+        public override SyntaxNode VisitTableExtension(TableExtensionSyntax node)
+        {
+            _tableDataClassification = null;
+            return base.VisitTableExtension(node);
         }
 
         public override SyntaxNode VisitField(FieldSyntax node)

--- a/language-server/Shared.AnZwDev.ALTools/CodeTransformations/RemoveRedundantDataClassificationSyntaxRewriter.cs
+++ b/language-server/Shared.AnZwDev.ALTools/CodeTransformations/RemoveRedundantDataClassificationSyntaxRewriter.cs
@@ -31,7 +31,15 @@ namespace AnZwDev.ALTools.CodeTransformations
                     _tableDataClassification = fieldsDataClassification;
                 }
             }
-            return base.VisitTable(node);
+            var tableNode = base.VisitTable(node);
+            _tableDataClassification = null;
+            return tableNode;
+        }
+
+        public override SyntaxNode VisitTableExtension(TableExtensionSyntax node)
+        {
+            _tableDataClassification = null;
+            return base.VisitTableExtension(node);
         }
 
         public override SyntaxNode VisitField(FieldSyntax node)

--- a/language-server/Shared.AnZwDev.ALTools/CodeTransformations/SortProceduresTriggerSortMode.cs
+++ b/language-server/Shared.AnZwDev.ALTools/CodeTransformations/SortProceduresTriggerSortMode.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.CodeTransformations
+{
+    public enum SortProceduresTriggerSortMode
+    {
+
+        None = 0,
+        Name = 1,
+        NaturalOrder = 2
+
+    }
+}

--- a/language-server/Shared.AnZwDev.ALTools/CodeTransformations/TriggersOrder.cs
+++ b/language-server/Shared.AnZwDev.ALTools/CodeTransformations/TriggersOrder.cs
@@ -1,0 +1,48 @@
+﻿using AnZwDev.ALTools.ALSymbols.Internal;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Xml.Linq;
+
+namespace AnZwDev.ALTools.CodeTransformations
+{
+
+    internal class TriggersOrder
+    {
+        public ConvertedSyntaxKind Kind { get; }
+        public string[] Triggers { get; }
+        private Dictionary<string, int> _triggersOrder = new Dictionary<string, int>();
+
+        public TriggersOrder(ConvertedSyntaxKind kind, string[] triggers)
+        {
+            this.Kind = kind;
+            this.Triggers = triggers;
+
+            for (int i = 0; i < this.Triggers.Length; i++)
+            {
+                this.Triggers[i] = this.Triggers[i].ToLower();
+                this._triggersOrder.Add(triggers[i], i);
+            }
+        }
+
+        public int Compare(string nameX, string nameY)
+        {
+            nameX = nameX.ToLower();
+            nameY = nameY.ToLower();
+            bool containsX = this._triggersOrder.ContainsKey(nameX);
+            bool containsY = this._triggersOrder.ContainsKey(nameY);
+
+            if (containsX && containsY)
+                return _triggersOrder[nameX] - _triggersOrder[nameY];
+            else if (containsX)
+                return -1;
+            else if (containsY)
+                return 1;
+            else
+                return StringComparer.OrdinalIgnoreCase.Compare(nameX, nameY);
+        }
+
+    }
+}

--- a/language-server/Shared.AnZwDev.ALTools/CodeTransformations/TriggersOrderCollection.cs
+++ b/language-server/Shared.AnZwDev.ALTools/CodeTransformations/TriggersOrderCollection.cs
@@ -1,0 +1,231 @@
+﻿using AnZwDev.ALTools.ALSymbols.Internal;
+using AnZwDev.ALTools.Extensions;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.CodeTransformations
+{
+    internal class TriggersOrderCollection
+    {
+
+        private readonly Dictionary<ConvertedSyntaxKind, TriggersOrder> _nodeTriggers = new Dictionary<ConvertedSyntaxKind, TriggersOrder>();
+
+        public TriggersOrderCollection()
+        {
+            SetDefault();
+        }
+
+        public void Add(TriggersOrder triggersOrder)
+        {
+            if (_nodeTriggers.ContainsKey(triggersOrder.Kind))
+                _nodeTriggers[triggersOrder.Kind] = triggersOrder;
+            else
+                _nodeTriggers.Add(triggersOrder.Kind, triggersOrder);
+        }
+
+        public void AddRange(IEnumerable<TriggersOrder> triggersOrders)
+        {
+            foreach (var trigger in triggersOrders)
+                Add(trigger);
+        }
+
+        public bool TryCompare(ConvertedSyntaxKind kind, string nameX, string nameY, out int result)
+        {
+            if (_nodeTriggers.ContainsKey(kind))
+            {
+                result = _nodeTriggers[kind].Compare(nameX, nameY);
+                return true;
+            }
+            result = 0;
+            return false;
+        }
+
+        public void Clear()
+        {
+            _nodeTriggers.Clear();
+        }
+
+        public void SetDefault()
+        {
+            this.Clear();
+            this.Add(new TriggersOrder(ConvertedSyntaxKind.CodeunitObject, new string[]{
+                "OnRun",
+                "OnCheckPreconditionsPerDatabase",
+                "OnCheckPreconditionsPerCompany",
+                "OnUpgradePerDatabase",
+                "OnUpgradePerCompany",
+                "OnValidateUpgradePerDatabase",
+                "OnValidateUpgradePerCompany",
+                "OnInstallAppPerDatabase",
+                "OnInstallAppPerCompany",
+                "OnBeforeTestRun",
+                "OnAfterTestRun"
+            }));
+            this.Add(new TriggersOrder(ConvertedSyntaxKind.TableObject, new string[]{
+                "OnInsert",
+                "OnModify",
+                "OnDelete",
+                "OnRename"
+            }));
+            this.Add(new TriggersOrder(ConvertedSyntaxKind.TableExtensionObject, new string[]{
+                "OnBeforeInsert",
+                "OnInsert",
+                "OnAfterInsert",
+                "OnBeforeModify",
+                "OnModify",
+                "OnAfterModify",
+                "OnBeforeDelete",
+                "OnDelete",
+                "OnAfterDelete",
+                "OnBeforeRename",
+                "OnRename",
+                "OnAfterRename"
+            }));
+            this.Add(new TriggersOrder(ConvertedSyntaxKind.Field, new string[]{
+                "OnValidate",
+                "OnLookup"
+            }));
+            this.Add(new TriggersOrder(ConvertedSyntaxKind.FieldModification, new string[]{
+                "OnBeforeValidate",
+                "OnAfterValidate"
+            }));
+            this.Add(new TriggersOrder(ConvertedSyntaxKind.PageObject, new string[]{
+                "OnInit",
+                "OnOpenPage",
+                "OnClosePage",
+                "OnFindRecord",
+                "OnNextRecord",
+                "OnAfterGetRecord",
+                "OnNewRecord",
+                "OnInsertRecord",
+                "OnModifyRecord",
+                "OnDeleteRecord",
+                "OnQueryClosePage",
+                "OnAfterGetCurrRecord",
+                "OnPageBackgroundTaskCompleted",
+                "OnPageBackgroundTaskError"
+            }));
+            this.Add(new TriggersOrder(ConvertedSyntaxKind.RequestPage, new string[]{
+                "OnInit",
+                "OnOpenPage",
+                "OnClosePage",
+                "OnFindRecord",
+                "OnNextRecord",
+                "OnAfterGetRecord",
+                "OnNewRecord",
+                "OnInsertRecord",
+                "OnModifyRecord",
+                "OnDeleteRecord",
+                "OnQueryClosePage",
+                "OnAfterGetCurrRecord"
+            }));
+            this.Add(new TriggersOrder(ConvertedSyntaxKind.RequestPageExtension, new string[]{
+                "OnOpenPage",
+                "OnClosePage",
+                "OnAfterGetRecord",
+                "OnNewRecord",
+                "OnInsertRecord",
+                "OnModifyRecord",
+                "OnDeleteRecord",
+                "OnQueryClosePage",
+                "OnAfterGetCurrRecord"
+            }));
+            this.Add(new TriggersOrder(ConvertedSyntaxKind.PageExtensionObject, new string[]{
+                "OnOpenPage",
+                "OnClosePage",
+                "OnAfterGetRecord",
+                "OnNewRecord",
+                "OnInsertRecord",
+                "OnModifyRecord",
+                "OnDeleteRecord",
+                "OnQueryClosePage",
+                "OnAfterGetCurrRecord",
+                "OnPageBackgroundTaskCompleted",
+                "OnPageBackgroundTaskError"
+            }));
+            this.Add(new TriggersOrder(ConvertedSyntaxKind.PageField, new string[]
+            {
+                "OnValidate",
+                "OnLookup",
+                "OnAfterLookup",
+                "OnDrillDown",
+                "OnAssistEdit",
+                "OnControlAddIn"
+            }));
+            this.Add(new TriggersOrder(ConvertedSyntaxKind.ControlModifyChange, new string[]
+            {
+                "OnBeforeValidate",
+                "OnAfterValidate",
+                "OnLookup",
+                "OnDrillDown",
+                "OnAssistEdit",
+                "OnAfterAfterLookup"
+            }));
+            this.Add(new TriggersOrder(ConvertedSyntaxKind.PageAction, new string[]{
+                "OnAction"
+            }));
+            this.Add(new TriggersOrder(ConvertedSyntaxKind.ActionModifyChange, new string[]{
+                "OnBeforeAction",
+                "OnAfterAction"
+            }));
+            this.Add(new TriggersOrder(ConvertedSyntaxKind.ReportObject, new string[]{
+                "OnInitReport",
+                "OnPreReport",
+                "OnPostReport"
+            }));
+            this.Add(new TriggersOrder(ConvertedSyntaxKind.ReportExtension, new string[]{
+                "OnPreReport",
+                "OnPostReport"
+            }));
+            this.Add(new TriggersOrder(ConvertedSyntaxKind.ReportDataItem, new string[]{
+                "OnPreDataItem",
+                "OnAfterGetRecord",
+                "OnPostDataItem"
+            }));
+            this.Add(new TriggersOrder(ConvertedSyntaxKind.ReportExtensionDataSetModify, new string[]{
+                "OnBeforePreDataItem",
+                "OnAfterPreDataItem",
+                "OnBeforeAfterGetRecord",
+                "OnAfterAfterGetRecord",
+                "OnBeforePostDataItem",
+                "OnAfterPostDataItem"
+            }));
+            this.Add(new TriggersOrder(ConvertedSyntaxKind.XmlPortObject, new string[]{
+                "OnInitXmlPort",
+                "OnPreXmlPort",
+                "OnPostXmlPort"
+            }));
+            this.Add(new TriggersOrder(ConvertedSyntaxKind.XmlPortTableElement, new string[]{
+                "OnAfterInitRecord",
+                "OnBeforeInsertRecord",
+                "OnAfterInsertRecord",
+                "OnBeforeModifyRecord",
+                "OnAfterModifyRecord",
+                "OnPreXmlItem",
+                "OnAfterGetRecord"
+            }));
+            this.Add(new TriggersOrder(ConvertedSyntaxKind.XmlPortFieldElement, new string[]{
+                "OnAfterAssignField",
+                "OnBeforePassField"
+            }));
+            this.Add(new TriggersOrder(ConvertedSyntaxKind.XmlPortTextElement, new string[]{
+                "OnAfterAssignVariable",
+                "OnBeforePassVariable"
+            }));
+            this.Add(new TriggersOrder(ConvertedSyntaxKind.XmlPortFieldAttribute, new string[]{
+                "OnAfterAssignField",
+                "OnBeforePassField"
+            }));
+            this.Add(new TriggersOrder(ConvertedSyntaxKind.XmlPortTextAttribute, new string[]{
+                "OnAfterAssignVariable",
+                "OnBeforePassVariable"
+            }));
+            this.Add(new TriggersOrder(ConvertedSyntaxKind.QueryObject, new string[]{
+                "OnBeforeOpen"
+            }));
+        }
+
+    }
+}

--- a/language-server/Shared.AnZwDev.ALTools/Extensions/DictionaryExtensions.cs
+++ b/language-server/Shared.AnZwDev.ALTools/Extensions/DictionaryExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -20,6 +21,32 @@ namespace AnZwDev.ALTools.Extensions
             if (String.IsNullOrWhiteSpace(value))
                 return defaultValue;
             return ((value.ToLower() == "true") || (value == "1"));
+        }
+
+        public static T GetJsonValue<T>(this Dictionary<string, string> dictionary, string key, T defaultValue = null) where T : class
+        {
+            string value = dictionary.GetStringValue(key);
+            if (!String.IsNullOrWhiteSpace(value))
+            {
+                try
+                {
+                    return JsonConvert.DeserializeObject<T>(value);
+                }
+                catch (Exception) { }
+            }
+            return defaultValue;            
+        }
+
+        public static T GetEnumValue<T>(this Dictionary<string, string> dictionary, string key, T defaultValue) where T : struct
+        {
+            string value = dictionary.GetStringValue(key);
+            if (!String.IsNullOrWhiteSpace(value))
+            {
+                T enumValue;
+                if (Enum.TryParse<T>(value, true, out enumValue))
+                    return enumValue;
+            }
+            return defaultValue;
         }
 
         public static List<string> GetStringListValue(this Dictionary<string, string> dictionary, string keyPrefix)

--- a/language-server/Shared.AnZwDev.ALTools/Extensions/SyntaxNodeExtensions.cs
+++ b/language-server/Shared.AnZwDev.ALTools/Extensions/SyntaxNodeExtensions.cs
@@ -175,6 +175,22 @@ namespace AnZwDev.ALTools.Extensions
             return false;
         }
 
+        internal static bool HasParents(this SyntaxNode node, params ConvertedSyntaxKind[] parentNodeKind)
+        {
+            int nodeKindIndex = 0;
+            while (node != null)
+            {
+                if (node.Kind.ConvertToLocalType() == parentNodeKind[nodeKindIndex])
+                {
+                    nodeKindIndex++;
+                    if (nodeKindIndex >= parentNodeKind.Length)
+                        return true;
+                }
+                node = node.Parent;
+            }
+            return false;
+        }
+
         internal static SyntaxNode FindParentByKind(this SyntaxNode node, params ConvertedSyntaxKind[] parentNodeKind)
         {
             while (node != null)

--- a/language-server/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
+++ b/language-server/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
@@ -207,6 +207,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\RemoveEmptyTriggersSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\RemoveEventPublishersSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\RemoveRedundantDataClassificationSyntaxRewriter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\SortProceduresTriggerSortMode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\TriggersOrder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\TriggersOrderCollection.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\Parameters\TriggersOrderParameter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\RemoveRedundantDataClassificationWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\RemoveStrSubstNoFromErrorSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\RemoveUnusedVariablesSyntaxRewriter.cs" />

--- a/language-server/Shared.AnZwDev.ALTools/WorkspaceCommands/Parameters/TriggersOrderParameter.cs
+++ b/language-server/Shared.AnZwDev.ALTools/WorkspaceCommands/Parameters/TriggersOrderParameter.cs
@@ -1,0 +1,74 @@
+﻿using AnZwDev.ALTools.ALSymbols.Internal;
+using AnZwDev.ALTools.CodeTransformations;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.WorkspaceCommands.Parameters
+{
+    internal class TriggersOrderParameter
+    {
+
+        [JsonProperty("parent")]
+        public string Parent { get; set; }
+
+        [JsonProperty("order")]
+        public string[] Triggers { get; set; }
+
+        public TriggersOrderParameter()
+        { 
+        }
+
+        public TriggersOrder ToTriggersOrder()
+        {
+            //try to convert 
+            if ((!String.IsNullOrEmpty(Parent)) && 
+                (this.Triggers != null) && 
+                (this.Triggers.Length > 0))
+            {
+                var kind = ConvertParentToKind();
+                if (kind != ConvertedSyntaxKind.None)
+                    return new TriggersOrder(kind, this.Triggers);
+            }
+            return null;
+        }
+
+        private ConvertedSyntaxKind ConvertParentToKind()
+        {
+            if (Enum.TryParse<ConvertedSyntaxKind>(Parent, true, out var kind))
+                return kind;
+
+            switch (Parent.ToLower())
+            {
+                case "codeunit": return ConvertedSyntaxKind.CodeunitObject;
+                case "table": return ConvertedSyntaxKind.TableObject;
+                case "tableextension": return ConvertedSyntaxKind.TableExtensionObject;
+                case "field": return ConvertedSyntaxKind.Field;
+                case "fieldextension": return ConvertedSyntaxKind.FieldModification;
+                case "page": return ConvertedSyntaxKind.PageObject;
+                case "requestpage": return ConvertedSyntaxKind.RequestPage;
+                case "requestpageextension": return ConvertedSyntaxKind.RequestPageExtension;
+                case "pageextension": return ConvertedSyntaxKind.PageExtensionObject;
+                case "pagefield": return ConvertedSyntaxKind.PageField;
+                case "pagefieldextension": return ConvertedSyntaxKind.ControlModifyChange;
+                case "action": return ConvertedSyntaxKind.PageAction;
+                case "actionextension": return ConvertedSyntaxKind.ActionModifyChange;
+                case "report": return ConvertedSyntaxKind.ReportObject;
+                case "reportextension": return ConvertedSyntaxKind.ReportExtension;
+                case "reportdataitem": return ConvertedSyntaxKind.ReportDataItem;
+                case "reportextensiondatasetmodify": return ConvertedSyntaxKind.ReportExtensionDataSetModify;
+                case "xmlport": return ConvertedSyntaxKind.XmlPortObject;
+                case "xmlporttableelement": return ConvertedSyntaxKind.XmlPortTableElement;
+                case "xmlportfieldelement": return ConvertedSyntaxKind.XmlPortFieldElement;
+                case "xmlporttextelement": return ConvertedSyntaxKind.XmlPortTextElement;
+                case "xmlportfieldattribute": return ConvertedSyntaxKind.XmlPortFieldAttribute;
+                case "xmlporttextattribute": return ConvertedSyntaxKind.XmlPortTextAttribute;
+                case "query": return ConvertedSyntaxKind.QueryObject;
+            }
+            return ConvertedSyntaxKind.None;
+        }
+
+
+    }
+}

--- a/language-server/Shared.AnZwDev.ALTools/WorkspaceCommands/SortProceduresWorkspaceCommand.cs
+++ b/language-server/Shared.AnZwDev.ALTools/WorkspaceCommands/SortProceduresWorkspaceCommand.cs
@@ -1,15 +1,37 @@
 ﻿using AnZwDev.ALTools.CodeTransformations;
+using AnZwDev.ALTools.Extensions;
+using AnZwDev.ALTools.WorkspaceCommands.Parameters;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
 using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace AnZwDev.ALTools.WorkspaceCommands
 {
-    public class SortProceduresWorkspaceCommand : SyntaxRewriterWorkspaceCommand<SortProceduresSyntaxRewriter>
+    internal class SortProceduresWorkspaceCommand : SyntaxRewriterWorkspaceCommand<SortProceduresSyntaxRewriter>
     {
+
+        public static string TriggersSortModeParameterName = "triggersSortMode";
+        public static string TriggersNaturalOrderParameterName = "triggersNaturalOrder";
 
         public SortProceduresWorkspaceCommand(ALDevToolsServer alDevToolsServer) : base(alDevToolsServer, "sortProcedures")
         {
+        }
+
+        protected override void SetParameters(string sourceCode, string projectPath, string filePath, TextSpan span, Dictionary<string, string> parameters)
+        {
+            base.SetParameters(sourceCode, projectPath, filePath, span, parameters);
+
+            if (parameters.ContainsKey(TriggersSortModeParameterName))
+                this.SyntaxRewriter.TriggerSortMode = parameters.GetEnumValue(TriggersSortModeParameterName, SortProceduresTriggerSortMode.None);
+
+            if (parameters.ContainsKey(TriggersNaturalOrderParameterName))
+            {
+                var triggersOrder = parameters.GetJsonValue<TriggersOrderParameter[]>(TriggersNaturalOrderParameterName);
+                if (triggersOrder != null)
+                    for (int i = 0; i < triggersOrder.Length; i++)
+                        this.SyntaxRewriter.TriggersOrder.Add(triggersOrder[i].ToTriggersOrder());
+            }
         }
 
     }

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "al-code-outline",
-	"version": "3.0.45",
+	"version": "3.0.46",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1818,14 +1818,105 @@
 							"mainTypeNameOnlyKeepVariableNameOrder"
 						],
 						"enumDescriptions": [
-							"Sort report DataItem columns",
-							"Format document"
+							"Full type name",
+							"Main type name only",
+							"Full type name, keep variable name order",
+							"Main type name only, keep variable name order"
 						],
 						"default": "fullTypeName",
 						"description": "Specifies how variables are sorted by `Sort Variables` commands.",
 						"scope": "resource"						
 					},
-
+					"alOutline.triggersSortMode": {
+						"type": "string",
+						"enum": [
+							"None",
+							"Name",
+							"NaturalOrder"
+						],
+						"enumDescriptions": [
+							"None",
+							"Name",
+							"Natural order"
+						],
+						"default": "None",
+						"description": "Specifies how triggers are sorted by `Sort Procedures` commands.",
+						"scope": "resource"
+					},
+					"alOutline.triggersNaturalOrder": {
+						"type":"array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"parent": {
+									"type": "string",
+									"description": "Type of syntax node containing triggers",
+									"enum": [
+										"Table",
+										"TableExtension",
+										"Page",
+										"PageExtension",
+										"RequestPage",
+										"RequestPageExtension",
+										"Report",
+										"ReportExtension",
+										"XmlPort",
+										"Codeunit",
+										"Query",
+										"Field",
+										"FieldExtension",
+										"PageField",
+										"PageFieldExtension",
+										"Action",
+										"ActionExtension",
+										"ReportDataItem",
+										"ReportExtensionDataSetModify",
+										"XmlPortTableElement",
+										"XmlPortFieldElement",
+										"XmlPortTextElement",
+										"XmlPortFieldAttribute",
+										"XmlPortTextAttribute"
+									],
+									"enumDescriptions": [
+										"Table",
+										"Table Extension",
+										"Page",
+										"Page Extension",
+										"Request Page",
+										"Request Page Extension",
+										"Report",
+										"Report Extension",
+										"XmlPort",
+										"Codeunit",
+										"Query",
+										"Field",
+										"Field Extension",
+										"Page Field",
+										"Page Field Extension",
+										"Action",
+										"Action Extension",
+										"Report DataItem",
+										"Report Extension DataSet Modify",
+										"XmlPort Table Element",
+										"XmlPort Field Element",
+										"XmlPort Text Element",
+										"XmlPort Field Attribute",
+										"XmlPort Text Attribute"
+									]
+								},
+								"order": {
+									"type": "array",
+									"items": {
+										"type": "string"
+									},
+									"description": "List of trigger names in desired order"
+								}
+							}
+						},
+						"default": [],
+						"description": "Specifies natural order of triggers for `Sort Procedures` commands.",
+						"scope": "resource"
+					},
 					"alOutline.dropDownGroupFieldsNamesPatterns": {
 						"type": "array",
 						"items": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
 	"name": "al-code-outline",
 	"displayName": "AZ AL Dev Tools/AL Code Outline",
 	"description": "AZ AL Development Tools: AL code outline, object browser, object creators",
-	"version": "3.0.45",
+	"version": "3.0.46",
 	"publisher": "andrzejzwierzchowski",
 	"engines": {
 		"vscode": "^1.47.0"

--- a/vscode-extension/src/alsyntaxmodifiers/sortProceduresModifier.ts
+++ b/vscode-extension/src/alsyntaxmodifiers/sortProceduresModifier.ts
@@ -1,3 +1,4 @@
+import * as vscode from 'vscode';
 import { DevToolsExtensionContext } from "../devToolsExtensionContext";
 import { WorkspaceCommandSyntaxModifier } from "./workspaceCommandSyntaxModifier";
 
@@ -6,5 +7,14 @@ export class SortProceduresModifier  extends WorkspaceCommandSyntaxModifier {
     constructor(context: DevToolsExtensionContext) {
         super(context, "Sort Procedures", "sortProcedures");
     }
+
+    protected getParameters(uri: vscode.Uri): any {      
+        let parameters = super.getParameters(uri);
+        let settings = vscode.workspace.getConfiguration('alOutline', uri);                
+        parameters.triggersSortMode = settings.get<string>('triggersSortMode');
+        parameters.triggersNaturalOrder = JSON.stringify(settings.get('triggersNaturalOrder'));
+        return parameters;
+    }
+
 
 }

--- a/vscode-extension/src/objectwizards/wizards/alCodeunitWizard.ts
+++ b/vscode-extension/src/objectwizards/wizards/alCodeunitWizard.ts
@@ -17,7 +17,7 @@ export class ALCodeunitWizard extends ALObjectWizard {
 
     protected async runAsync(settings: ALObjectWizardSettings) {
         let wizardData : ALCodeunitWizardData = new ALCodeunitWizardData();
-        this.initObjectIdFields(wizardData, settings, "Codeunit");
+        await this.initObjectIdFieldsAsync(wizardData, settings, "Codeunit");
         wizardData.objectName = '';//settings.getInputNameVariable();
         this.onInitWizardData(wizardData);
         let wizardPage : ALCodeunitWizardPage = new ALCodeunitWizardPage(this._toolsExtensionContext, settings, wizardData);

--- a/vscode-extension/src/objectwizards/wizards/alEnumExtWizard.ts
+++ b/vscode-extension/src/objectwizards/wizards/alEnumExtWizard.ts
@@ -17,7 +17,7 @@ export class ALEnumExtWizard extends ALObjectWizard {
 
     protected async runAsync(settings: ALObjectWizardSettings) {
         let wizardData : ALEnumExtWizardData = new ALEnumExtWizardData();
-        this.initObjectIdFields(wizardData, settings, "enumextension");
+        await this.initObjectIdFieldsAsync(wizardData, settings, "enumextension");
         wizardData.objectName = '';
         wizardData.firstValueId = this._toolsExtensionContext.alLangProxy.getIdRangeStart(settings.getDestDirectoryUri());
         this.onInitWizardData(wizardData);

--- a/vscode-extension/src/objectwizards/wizards/alEnumWizard.ts
+++ b/vscode-extension/src/objectwizards/wizards/alEnumWizard.ts
@@ -19,7 +19,7 @@ export class ALEnumWizard extends ALObjectWizard {
 
     protected async runAsync(settings: ALObjectWizardSettings) {
         let wizardData : ALEnumWizardData = new ALEnumWizardData();
-        this.initObjectIdFields(wizardData, settings, "enum");
+        await this.initObjectIdFieldsAsync(wizardData, settings, "enum");
         wizardData.objectName = '';
         this.onInitWizardData(wizardData);
         let wizardPage : ALEnumWizardPage = new ALEnumWizardPage(this._toolsExtensionContext, settings, wizardData);

--- a/vscode-extension/src/objectwizards/wizards/alObjectWizard.ts
+++ b/vscode-extension/src/objectwizards/wizards/alObjectWizard.ts
@@ -19,7 +19,7 @@ export class ALObjectWizard {
     run(settings: ALObjectWizardSettings) {
     }
 
-    async initObjectIdFields(data: ALObjectWizardData, settings: ALObjectWizardSettings, type: string) {
+    async initObjectIdFieldsAsync(data: ALObjectWizardData, settings: ALObjectWizardSettings, type: string) {
         let uri = settings.getDestDirectoryUri();
         let idProviders = this._toolsExtensionContext.idReservationService.getReservationProviders(uri); 
         let idProviderName = ((idProviders) && (idProviders.length === 1))? idProviders[0] : this._toolsExtensionContext.idReservationService.getDefaultProviderName();

--- a/vscode-extension/src/objectwizards/wizards/alPageExtWizard.ts
+++ b/vscode-extension/src/objectwizards/wizards/alPageExtWizard.ts
@@ -17,7 +17,7 @@ export class ALPageExtWizard extends ALObjectWizard {
 
     protected async runAsync(settings: ALObjectWizardSettings) {
         let wizardData : ALPageExtWizardData = new ALPageExtWizardData();
-        this.initObjectIdFields(wizardData, settings, "pageextension");
+        await this.initObjectIdFieldsAsync(wizardData, settings, "pageextension");
         wizardData.objectName = '';
         wizardData.basePage = '';
         this.onInitWizardData(wizardData);

--- a/vscode-extension/src/objectwizards/wizards/alPageWizard.ts
+++ b/vscode-extension/src/objectwizards/wizards/alPageWizard.ts
@@ -23,7 +23,7 @@ export class ALPageWizard extends ALObjectWizard {
         let config = vscode.workspace.getConfiguration('alOutline', settings.getDestDirectoryUri());
 
         let wizardData : ALPageWizardData = new ALPageWizardData();
-        this.initObjectIdFields(wizardData, settings, "Page");
+        await this.initObjectIdFieldsAsync(wizardData, settings, "Page");
         wizardData.objectName = '';//settings.getInputNameVariable();
         wizardData.createTooltips = !!config.get<boolean>('addToolTipsToPageFields');
         wizardData.reuseToolTips = !config.get<boolean>('doNotReuseToolTipsFromOtherPages');

--- a/vscode-extension/src/objectwizards/wizards/alPermissionSetExtensionWizard.ts
+++ b/vscode-extension/src/objectwizards/wizards/alPermissionSetExtensionWizard.ts
@@ -16,7 +16,7 @@ export class ALPermissionSetExtensionWizard extends ALObjectWizard {
 
     protected async runAsync(settings: ALObjectWizardSettings) {
         let wizardData : ALPermissionSetExtensionWizardData = new ALPermissionSetExtensionWizardData();
-        this.initObjectIdFields(wizardData, settings, "permissionsetextension");
+        await this.initObjectIdFieldsAsync(wizardData, settings, "permissionsetextension");
         wizardData.objectName = '';
         this.onInitWizardData(wizardData);
         let wizardPage : ALPermissionSetExtensionWizardPage = new ALPermissionSetExtensionWizardPage(this._toolsExtensionContext, settings, wizardData);

--- a/vscode-extension/src/objectwizards/wizards/alPermissionSetWizard.ts
+++ b/vscode-extension/src/objectwizards/wizards/alPermissionSetWizard.ts
@@ -16,7 +16,7 @@ export class ALPermissionSetWizard extends ALObjectWizard {
 
     protected async runAsync(settings: ALObjectWizardSettings) {
         let wizardData : ALPermissionSetWizardData = new ALPermissionSetWizardData();
-        this.initObjectIdFields(wizardData, settings, "permissionset");
+        await this.initObjectIdFieldsAsync(wizardData, settings, "permissionset");
         wizardData.objectName = '';
         this.onInitWizardData(wizardData);
         let wizardPage : ALPermissionSetWizardPage = new ALPermissionSetWizardPage(this._toolsExtensionContext, undefined, settings, wizardData);

--- a/vscode-extension/src/objectwizards/wizards/alQueryWizard.ts
+++ b/vscode-extension/src/objectwizards/wizards/alQueryWizard.ts
@@ -20,7 +20,7 @@ export class ALQueryWizard extends ALObjectWizard {
 
     protected async runAsync(settings: ALObjectWizardSettings) {
         let wizardData : ALQueryWizardData = new ALQueryWizardData();
-        this.initObjectIdFields(wizardData, settings, "Query");
+        await this.initObjectIdFieldsAsync(wizardData, settings, "Query");
         wizardData.objectName = '';
         this.onInitWizardData(wizardData);
         let wizardPage : ALQueryWizardPage = new ALQueryWizardPage(this._toolsExtensionContext, settings, wizardData);

--- a/vscode-extension/src/objectwizards/wizards/alReportExtWizard.ts
+++ b/vscode-extension/src/objectwizards/wizards/alReportExtWizard.ts
@@ -17,7 +17,7 @@ export class ALReportExtWizard extends ALObjectWizard {
 
     protected async runAsync(settings: ALObjectWizardSettings) {
         let wizardData : ALReportExtWizardData = new ALReportExtWizardData();
-        this.initObjectIdFields(wizardData, settings, "reportextension");
+        await this.initObjectIdFieldsAsync(wizardData, settings, "reportextension");
         wizardData.objectName = '';
         wizardData.baseReport = '';
         this.onInitWizardData(wizardData);

--- a/vscode-extension/src/objectwizards/wizards/alReportWizard.ts
+++ b/vscode-extension/src/objectwizards/wizards/alReportWizard.ts
@@ -20,7 +20,7 @@ export class ALReportWizard extends ALObjectWizard {
 
     protected async runAsync(settings: ALObjectWizardSettings) {
         let wizardData : ALReportWizardData = new ALReportWizardData();
-        this.initObjectIdFields(wizardData, settings, "Report");
+        await this.initObjectIdFieldsAsync(wizardData, settings, "Report");
         wizardData.objectName = '';
         
         //build relative path

--- a/vscode-extension/src/objectwizards/wizards/alTableExtWizard.ts
+++ b/vscode-extension/src/objectwizards/wizards/alTableExtWizard.ts
@@ -20,7 +20,7 @@ export class ALTableExtWizard extends ALObjectWizard {
 
     protected async runAsync(settings: ALObjectWizardSettings) {
         let wizardData : ALTableExtWizardData = new ALTableExtWizardData();
-        this.initObjectIdFields(wizardData, settings, "tableextension");
+        await this.initObjectIdFieldsAsync(wizardData, settings, "tableextension");
         wizardData.objectName = '';
         wizardData.selectedTable = '';
         wizardData.idRangeStart = 

--- a/vscode-extension/src/objectwizards/wizards/alTableWizard.ts
+++ b/vscode-extension/src/objectwizards/wizards/alTableWizard.ts
@@ -20,7 +20,7 @@ export class ALTableWizard extends ALObjectWizard {
 
     protected async runAsync(settings: ALObjectWizardSettings) {
         let wizardData : ALTableWizardData = new ALTableWizardData();
-        this.initObjectIdFields(wizardData, settings, "table");
+        await this.initObjectIdFieldsAsync(wizardData, settings, "table");
         wizardData.objectName = '';
         this.onInitWizardData(wizardData);
         let wizardPage : ALTableWizardPage = new ALTableWizardPage(this._toolsExtensionContext, settings, wizardData);

--- a/vscode-extension/src/objectwizards/wizards/alXmlPortWizard.ts
+++ b/vscode-extension/src/objectwizards/wizards/alXmlPortWizard.ts
@@ -19,7 +19,7 @@ export class ALXmlPortWizard extends ALObjectWizard {
 
     protected async runAsync(settings: ALObjectWizardSettings) {
         let wizardData : ALXmlPortWizardData = new ALXmlPortWizardData();
-        this.initObjectIdFields(wizardData, settings, "XmlPort");
+        await this.initObjectIdFieldsAsync(wizardData, settings, "XmlPort");
         wizardData.objectName = '';
         this.onInitWizardData(wizardData);
         let wizardPage : ALXmlPortWizardPage = new ALXmlPortWizardPage(this._toolsExtensionContext, settings, wizardData);


### PR DESCRIPTION
 - Issue #276 - AL Object ID Ninja wizards integration not always works
 - Issue #432 - Remove Redundant DataClassification removes it from table extension fields
 - Issue #444 - Completion provider seems to ignore 'internal' objects
 - Issue #465 - Order triggers according to their natural order
 - Issue #467 - AddMissingParentheses adds parentheses to function references in event subscribers (AL Runtime 11.x)