### PR TITLE
Version 3.0.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
    - new alOutline.keepVariableNamesCompletionAffixes setting added
  - Issue #473 - When reusing tooltip from another page, include the tooltip comment
  - Issue #474 - Remove with usage on codeunits with TableNo
+ - Linux version
 
 Thank you
  - rvanbekkum for reporting issue #470

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@
  - Issue #470 - Add "DataClassification" as table property to the "New Table Wizard"
  - Issue #472 - CodeCompletion - Do not Ignore Prefix in variable names
    - new alOutline.keepVariableNamesCompletionAffixes setting added
+ - Issue #474 - Remove with usage on codeunits with TableNo
 
 Thank you
  - rvanbekkum for reporting issue #470
  - Thyme1 for reporting issue #472
+ - smartinez-io for reprting issue #474
 
 ## 3.0.46
  - Issue #276 - AL Object ID Ninja wizards integration not always works

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
  - Issue #470 - Add "DataClassification" as table property to the "New Table Wizard"
  - Issue #472 - CodeCompletion - Do not Ignore Prefix in variable names
    - new alOutline.keepVariableNamesCompletionAffixes setting added
+ - Issue #473 - When reusing tooltip from another page, include the tooltip comment
  - Issue #474 - Remove with usage on codeunits with TableNo
 
 Thank you
  - rvanbekkum for reporting issue #470
  - Thyme1 for reporting issue #472
+ - jhoek for reporting issue #473
  - smartinez-io for reprting issue #474
 
 ## 3.0.46

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 3.0.47
+ - Issue #472 - CodeCompletion - Do not Ignore Prefix in variable names
+   - new alOutline.keepVariableNamesCompletionAffixes setting added
+
+Thank you
+ - Thyme1 for reporting issue #472
+
 ## 3.0.46
  - Issue #276 - AL Object ID Ninja wizards integration not always works
  - Issue #432 - Remove Redundant DataClassification removes it from table extension fields

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Change Log
 
 ## 3.0.47
+ - Issue #470 - Add "DataClassification" as table property to the "New Table Wizard"
  - Issue #472 - CodeCompletion - Do not Ignore Prefix in variable names
    - new alOutline.keepVariableNamesCompletionAffixes setting added
 
 Thank you
+ - rvanbekkum for reporting issue #470
  - Thyme1 for reporting issue #472
 
 ## 3.0.46

--- a/build.ps1
+++ b/build.ps1
@@ -190,6 +190,10 @@ dotnet publish ".\AZALDevToolsServer.NetCore\AZALDevToolsServer.NetCore.csproj" 
 Write-Host "Building MacOS .net core language server"
 dotnet publish ".\AZALDevToolsServer.NetCore\AZALDevToolsServer.NetCore.csproj" -r osx-x64 -f net6.0 -o "..\vscode-extension\bin\netcore\darwin" --self-contained true --configuration Release
 
+# Linux - .net core
+Write-Host "Building Linux .net core language server"
+dotnet publish ".\AZALDevToolsServer.NetCore\AZALDevToolsServer.NetCore.csproj" -r linux-x64 -f net6.0 -o "..\vscode-extension\bin\netcore\linux" --self-contained false --configuration Release
+
 # Windows - .net framework for Nav2018 extension development
 $msBuildPath = &"${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe
 & $msBuildPath ".\AZALDevToolsServer.NetFrameworkNav2018\AZALDevToolsServer.NetFrameworkNav2018.csproj" -p:Configuration=Release -p:OutputPath="..\..\vscode-extension\bin\netframeworknav2018"

--- a/language-server/AZALDevToolsTestConsoleApp/Program.cs
+++ b/language-server/AZALDevToolsTestConsoleApp/Program.cs
@@ -130,7 +130,7 @@ namespace AZALDevToolsTestConsoleApp
 
 
             PageInformationProvider pageInformationProvider = new PageInformationProvider();
-            List<string> toolTipsList = pageInformationProvider.GetPageFieldAvailableToolTips(project, "Page", "MyTestPage", "", "Rec.\"No.\"");
+            var toolTipsList = pageInformationProvider.GetPageFieldAvailableToolTips(project, "Page", "MyTestPage", "", "Rec.\"No.\"");
 
             PageInformation pageInformation = pageInformationProvider.GetPageDetails(project, "wqefewf", true, true, true, null);
 

--- a/language-server/AZALDevToolsTestConsoleApp/Program.cs
+++ b/language-server/AZALDevToolsTestConsoleApp/Program.cs
@@ -71,9 +71,10 @@ namespace AZALDevToolsTestConsoleApp
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\MyTestCU.al";
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\Cod50104.IdentifiersTest.al";
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\Rep50100.MyReport.al";
-            filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\MyTable.al";
+            //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\MyTable.al";
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\PageEmptySectionsTest.al";
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\WithTestsCU.al";
+            filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\CUWithTest.al";
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\CSVXmlPort.al";
 
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\Pag50105.MyItem3.al";
@@ -99,7 +100,7 @@ namespace AZALDevToolsTestConsoleApp
             //pm.Add("dependencyName2", "Microsoft - System Application");
             //pm.Add("dependencyName3", "Microsoft - Base Application");
 
-            //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeWith", content, projectPath, null, pm);
+            WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeWith", content, projects[0].folderPath, filePath, null, pm, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("addAllObjectsPermissions", content, projectPath, null, pm);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("fixIdentifiersCase", content, projects[0].folderPath, filePath, null, pm, null);
 
@@ -120,7 +121,7 @@ namespace AZALDevToolsTestConsoleApp
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("addReferencedTablesPermissions", content, projects[0].folderPath, filePath, null, pm, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("generateCSVXmlPortHeaders", content, projects[0].folderPath, filePath, null, pm, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeRedundantDataClassification", content, projects[0].folderPath, filePath, null, pm, null);
-            WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("sortProcedures", content, projects[0].folderPath, filePath, null, pm, null);
+            //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("sortProcedures", content, projects[0].folderPath, filePath, null, pm, null);
 
             ALProject project = host.ALDevToolsServer.Workspace.Projects[0];
 

--- a/language-server/Shared.AnZwDev.ALTools.Server/Contracts/CodeCompletionRequest.cs
+++ b/language-server/Shared.AnZwDev.ALTools.Server/Contracts/CodeCompletionRequest.cs
@@ -1,4 +1,5 @@
 ﻿using AnZwDev.ALTools.ALSymbols;
+using AnZwDev.ALTools.CodeCompletion;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -11,6 +12,7 @@ namespace AnZwDev.ALTools.Server.Contracts
         public Position position { get; set; }
         public string path { get; set; }
         public List<string> providers { get; set; }
+        public CodeCompletionParameters parameters { get; set; }
 
     }
 }

--- a/language-server/Shared.AnZwDev.ALTools.Server/Contracts/SymbolsInformation/GetPageFieldAvailableToolTipsResponse.cs
+++ b/language-server/Shared.AnZwDev.ALTools.Server/Contracts/SymbolsInformation/GetPageFieldAvailableToolTipsResponse.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using AnZwDev.ALTools.Workspace.SymbolsInformation;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -6,6 +7,6 @@ namespace AnZwDev.ALTools.Server.Contracts.SymbolsInformation
 {
     public class GetPageFieldAvailableToolTipsResponse
     {
-        public List<string> toolTips { get; set; }
+        public List<LabelInformation> toolTips { get; set; }
     }
 }

--- a/language-server/Shared.AnZwDev.ALTools.Server/Handlers/CodeCompletionRequestHandler.cs
+++ b/language-server/Shared.AnZwDev.ALTools.Server/Handlers/CodeCompletionRequestHandler.cs
@@ -31,6 +31,7 @@ namespace AnZwDev.ALTools.Server.Handlers
                     parameters.path,
                     parameters.position,
                     parameters.providers,
+                    parameters.parameters,
                     response.completionItems);
             }
             catch (Exception e)

--- a/language-server/Shared.AnZwDev.ALTools/CodeCompletion/CodeCompletionParameters.cs
+++ b/language-server/Shared.AnZwDev.ALTools/CodeCompletion/CodeCompletionParameters.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.CodeCompletion
+{
+    public class CodeCompletionParameters
+    {
+
+        [JsonProperty("keepVariableNamesAffixes")]
+        public bool KeepVariableNamesAffixes { get; set; }
+
+    }
+}

--- a/language-server/Shared.AnZwDev.ALTools/CodeCompletion/CodeCompletionProvider.cs
+++ b/language-server/Shared.AnZwDev.ALTools/CodeCompletion/CodeCompletionProvider.cs
@@ -20,7 +20,7 @@ namespace AnZwDev.ALTools.CodeCompletion
             Server = server;
         }
 
-        public virtual void CollectCompletionItems(ALProject project, SyntaxTree syntaxTree, SyntaxNode syntaxNode, int position, List<CodeCompletionItem> completionItems)
+        public virtual void CollectCompletionItems(ALProject project, SyntaxTree syntaxTree, SyntaxNode syntaxNode, int position, CodeCompletionParameters parameters, List<CodeCompletionItem> completionItems)
         {
         }
 

--- a/language-server/Shared.AnZwDev.ALTools/CodeCompletion/CodeCompletionProvidersCollection.cs
+++ b/language-server/Shared.AnZwDev.ALTools/CodeCompletion/CodeCompletionProvidersCollection.cs
@@ -31,13 +31,13 @@ namespace AnZwDev.ALTools.CodeCompletion
             _completionProviders.Add(provider.Name, provider);
         }
 
-        public void CollectCompletionItems(ALWorkspace workspace, string filePath, Position linePosition, List<string> providers, List<CodeCompletionItem> completionItems)
+        public void CollectCompletionItems(ALWorkspace workspace, string filePath, Position linePosition, List<string> providers, CodeCompletionParameters parameters, List<CodeCompletionItem> completionItems)
         {
             if ((workspace.ActiveDocument.Project != null) && (workspace.ActiveDocument.SyntaxTree != null))
-                CollectCompletionItems(workspace.ActiveDocument.Project, workspace.ActiveDocument.SyntaxTree, linePosition, providers, completionItems);
+                CollectCompletionItems(workspace.ActiveDocument.Project, workspace.ActiveDocument.SyntaxTree, linePosition, providers, parameters, completionItems);
         }
 
-        private void CollectCompletionItems(ALProject project, SyntaxTree syntaxTree, Position linePosition, List<string> providers, List<CodeCompletionItem> completionItems)
+        private void CollectCompletionItems(ALProject project, SyntaxTree syntaxTree, Position linePosition, List<string> providers, CodeCompletionParameters parameters, List<CodeCompletionItem> completionItems)
         {
             if ((providers != null) && (providers.Count > 0))
             {
@@ -54,7 +54,7 @@ namespace AnZwDev.ALTools.CodeCompletion
                         {
                             var provider = _completionProviders[providerName];
                             if (provider.CanBeUsed(providersNamesSet))
-                                provider.CollectCompletionItems(project, syntaxTree, syntaxNode, position, completionItems);
+                                provider.CollectCompletionItems(project, syntaxTree, syntaxNode, position, parameters, completionItems);
                         }
                     }
                 }

--- a/language-server/Shared.AnZwDev.ALTools/CodeCompletion/DirectiveCompletionProvider.cs
+++ b/language-server/Shared.AnZwDev.ALTools/CodeCompletion/DirectiveCompletionProvider.cs
@@ -18,7 +18,7 @@ namespace AnZwDev.ALTools.CodeCompletion
         {
         }
 
-        public override void CollectCompletionItems(ALProject project, SyntaxTree syntaxTree, SyntaxNode syntaxNode, int position, List<CodeCompletionItem> completionItems)
+        public override void CollectCompletionItems(ALProject project, SyntaxTree syntaxTree, SyntaxNode syntaxNode, int position, CodeCompletionParameters parameters, List<CodeCompletionItem> completionItems)
         {
             var directiveSyntax = syntaxTree.GetRoot()?
                 .GetFirstDirective(p => (p.FullSpan.Start <= position) && (p.FullSpan.End >= position));

--- a/language-server/Shared.AnZwDev.ALTools/CodeCompletion/VariableDataTypesCompletionProvider.cs
+++ b/language-server/Shared.AnZwDev.ALTools/CodeCompletion/VariableDataTypesCompletionProvider.cs
@@ -20,7 +20,7 @@ namespace AnZwDev.ALTools.CodeCompletion
         {
         }
 
-        public override void CollectCompletionItems(ALProject project, SyntaxTree syntaxTree, SyntaxNode syntaxNode, int position, List<CodeCompletionItem> completionItems)
+        public override void CollectCompletionItems(ALProject project, SyntaxTree syntaxTree, SyntaxNode syntaxNode, int position, CodeCompletionParameters parameters, List<CodeCompletionItem> completionItems)
         {
             var declaration = GetDeclaration(syntaxNode, position);
             if (declaration == null)

--- a/language-server/Shared.AnZwDev.ALTools/CodeCompletion/VariableNamesCompletionProvider.cs
+++ b/language-server/Shared.AnZwDev.ALTools/CodeCompletion/VariableNamesCompletionProvider.cs
@@ -32,29 +32,29 @@ namespace AnZwDev.ALTools.CodeCompletion
                 ((Name != _variableNamesName) || (!providerNames.Contains(_variableNamesWithTypeName)));
         }
 
-        public override void CollectCompletionItems(ALProject project, SyntaxTree syntaxTree, SyntaxNode syntaxNode, int position, List<CodeCompletionItem> completionItems)
+        public override void CollectCompletionItems(ALProject project, SyntaxTree syntaxTree, SyntaxNode syntaxNode, int position, CodeCompletionParameters parameters, List<CodeCompletionItem> completionItems)
         {
             (bool validNode, bool addSemicolon, bool addVarVersions) = ValidSyntaxNode(syntaxNode, position);
 
             if (validNode)
             {
-                CreateCompletionItems(project, completionItems, addSemicolon, false);
+                CreateCompletionItems(project, parameters, completionItems, addSemicolon, false);
                 if (addVarVersions)
-                    CreateCompletionItems(project, completionItems, addSemicolon, true);
+                    CreateCompletionItems(project, parameters, completionItems, addSemicolon, true);
             }
         }
 
-        private void CreateCompletionItems(ALProject project, List<CodeCompletionItem> completionItems, bool addSemicolon, bool addByVarDeclaration)
+        private void CreateCompletionItems(ALProject project, CodeCompletionParameters parameters, List<CodeCompletionItem> completionItems, bool addSemicolon, bool addByVarDeclaration)
         {
-            CreateCompletionItems(project, project.AllSymbols.Tables.GetObjects(), completionItems, false, addSemicolon, addByVarDeclaration);
-            CreateCompletionItems(project, project.AllSymbols.Tables.GetObjects(), completionItems, true, addSemicolon, addByVarDeclaration);
-            CreateCompletionItems(project, project.AllSymbols.Codeunits.GetObjects(), completionItems, false, addSemicolon, addByVarDeclaration);
-            CreateCompletionItems(project, project.AllSymbols.Pages.GetObjects(), completionItems, false, addSemicolon, addByVarDeclaration);
-            CreateCompletionItems(project, project.AllSymbols.Reports.GetObjects(), completionItems, false, addSemicolon, addByVarDeclaration);
-            CreateCompletionItems(project, project.AllSymbols.Queries.GetObjects(), completionItems, false, addSemicolon, addByVarDeclaration);
-            CreateCompletionItems(project, project.AllSymbols.XmlPorts.GetObjects(), completionItems, false, addSemicolon, addByVarDeclaration);
-            CreateCompletionItems(project, project.AllSymbols.EnumTypes.GetObjects(), completionItems, false, addSemicolon, addByVarDeclaration);
-            CreateCompletionItems(project, project.AllSymbols.Interfaces.GetObjects(), completionItems, false, addSemicolon, addByVarDeclaration);
+            CreateCompletionItems(project, project.AllSymbols.Tables.GetObjects(), parameters, completionItems, false, addSemicolon, addByVarDeclaration);
+            CreateCompletionItems(project, project.AllSymbols.Tables.GetObjects(), parameters, completionItems, true, addSemicolon, addByVarDeclaration);
+            CreateCompletionItems(project, project.AllSymbols.Codeunits.GetObjects(), parameters, completionItems, false, addSemicolon, addByVarDeclaration);
+            CreateCompletionItems(project, project.AllSymbols.Pages.GetObjects(), parameters, completionItems, false, addSemicolon, addByVarDeclaration);
+            CreateCompletionItems(project, project.AllSymbols.Reports.GetObjects(), parameters, completionItems, false, addSemicolon, addByVarDeclaration);
+            CreateCompletionItems(project, project.AllSymbols.Queries.GetObjects(), parameters, completionItems, false, addSemicolon, addByVarDeclaration);
+            CreateCompletionItems(project, project.AllSymbols.XmlPorts.GetObjects(), parameters, completionItems, false, addSemicolon, addByVarDeclaration);
+            CreateCompletionItems(project, project.AllSymbols.EnumTypes.GetObjects(), parameters, completionItems, false, addSemicolon, addByVarDeclaration);
+            CreateCompletionItems(project, project.AllSymbols.Interfaces.GetObjects(), parameters, completionItems, false, addSemicolon, addByVarDeclaration);
         }
 
         private (bool, bool, bool) ValidSyntaxNode(SyntaxNode syntaxNode, int position)
@@ -240,12 +240,14 @@ namespace AnZwDev.ALTools.CodeCompletion
             return null;
         }
 
-        private void CreateCompletionItems(ALProject project, IEnumerable<ALAppObject> typesCollection, List<CodeCompletionItem> completionItems, bool asTemporaryVariable, bool addSemicolon, bool addByVarDeclaration)
+        private void CreateCompletionItems(ALProject project, IEnumerable<ALAppObject> typesCollection, CodeCompletionParameters parameters, List<CodeCompletionItem> completionItems, bool asTemporaryVariable, bool addSemicolon, bool addByVarDeclaration)
         {
             foreach (var type in typesCollection)
             {
-                var varName = ALSyntaxHelper.ObjectNameToVariableNamePart(
-                    type.Name.RemovePrefixSuffix(project.MandatoryPrefixes, project.MandatorySuffixes, project.MandatoryAffixes, project.AdditionalMandatoryAffixesPatterns));
+                var varName = type.Name;
+                if ((parameters == null) || (!parameters.KeepVariableNamesAffixes))
+                    varName = varName.RemovePrefixSuffix(project.MandatoryPrefixes, project.MandatorySuffixes, project.MandatoryAffixes, project.AdditionalMandatoryAffixesPatterns);
+                varName = ALSyntaxHelper.ObjectNameToVariableNamePart(varName);
 
                 var addTemporary = (asTemporaryVariable) && (!varName.StartsWith(_tempPrefix, StringComparison.CurrentCultureIgnoreCase));
 

--- a/language-server/Shared.AnZwDev.ALTools/CodeTransformations/BaseToolTipsSyntaxRewriter.cs
+++ b/language-server/Shared.AnZwDev.ALTools/CodeTransformations/BaseToolTipsSyntaxRewriter.cs
@@ -1,5 +1,6 @@
 ﻿using AnZwDev.ALTools.CodeAnalysis;
 using AnZwDev.ALTools.Extensions;
+using AnZwDev.ALTools.Workspace.SymbolsInformation;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using System;
@@ -15,12 +16,17 @@ namespace AnZwDev.ALTools.CodeTransformations
         {
         }
 
-        protected PageFieldSyntax SetPageFieldToolTip(PageFieldSyntax node, string newToolTip)
+        protected PageFieldSyntax SetPageFieldToolTip(PageFieldSyntax node, LabelInformation newToolTip)
+        {
+            return SetPageFieldToolTip(node, newToolTip.Value, newToolTip.Comment);
+        }
+
+        protected PageFieldSyntax SetPageFieldToolTip(PageFieldSyntax node, string newToolTip, string newToolTipComment)
         {
             PropertySyntax propertySyntax = node.GetProperty("ToolTip");
             if (propertySyntax == null)
             {
-                var newPropertySyntax = SyntaxFactoryHelper.ToolTipProperty(newToolTip, "", false);
+                var newPropertySyntax = SyntaxFactoryHelper.ToolTipProperty(newToolTip, newToolTipComment, false);
 
                 /*
                 SyntaxTriviaList leadingTriviaList = node.CreateChildNodeIdentTrivia();
@@ -39,21 +45,13 @@ namespace AnZwDev.ALTools.CodeTransformations
                     validValue = ((labelValue.Value?.LabelText?.Value.Value?.ToString()) != newToolTip);
                 if (validValue)
                 {
-                    PropertySyntax newPropertySyntax = SyntaxFactoryHelper.ToolTipProperty(newToolTip, "", false)
+                    PropertySyntax newPropertySyntax = SyntaxFactoryHelper.ToolTipProperty(newToolTip, newToolTipComment, false)
                         .WithTriviaFrom(propertySyntax);
                     return node.ReplaceNode(propertySyntax, newPropertySyntax);
                 }
             }
             return null;
         }
-
-        protected PropertySyntax CreateToolTipProperty(string toolTipValue, SyntaxTriviaList leadingTriviaList, SyntaxTriviaList trailingTriviaList)
-        {
-            return SyntaxFactoryHelper.ToolTipProperty(toolTipValue, "", false)
-                .WithLeadingTrivia(leadingTriviaList)
-                .WithTrailingTrivia(trailingTriviaList);
-        }
-
 
     }
 }

--- a/language-server/Shared.AnZwDev.ALTools/CodeTransformations/RefreshToolTipsSyntaxRewriter.cs
+++ b/language-server/Shared.AnZwDev.ALTools/CodeTransformations/RefreshToolTipsSyntaxRewriter.cs
@@ -1,5 +1,6 @@
 ﻿using AnZwDev.ALTools.CodeAnalysis;
 using AnZwDev.ALTools.Extensions;
+using AnZwDev.ALTools.Workspace.SymbolsInformation;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using System;
@@ -11,7 +12,7 @@ namespace AnZwDev.ALTools.CodeTransformations
     public class RefreshToolTipsSyntaxRewriter : BaseToolTipsSyntaxRewriter
     {
 
-        public Dictionary<string, Dictionary<string, List<string>>> ToolTipsCache { get; set; }
+        public Dictionary<string, Dictionary<string, List<LabelInformation>>> ToolTipsCache { get; set; }
 
         public RefreshToolTipsSyntaxRewriter()
         {
@@ -32,14 +33,14 @@ namespace AnZwDev.ALTools.CodeTransformations
                 string tableNameKey = this.TableName.ToLower();
                 if (this.ToolTipsCache.ContainsKey(tableNameKey))
                 {
-                    Dictionary<string, List<string>> tableToolTipsCache = this.ToolTipsCache[tableNameKey];
+                    Dictionary<string, List<LabelInformation>> tableToolTipsCache = this.ToolTipsCache[tableNameKey];
                     string fieldNameKey = captionInfo.FieldName.ToLower();
                     if (tableToolTipsCache.ContainsKey(fieldNameKey))
                     {
-                        List<string> fieldToolTipsCache = tableToolTipsCache[fieldNameKey];
-                        if ((fieldToolTipsCache.Count > 0) && (!String.IsNullOrWhiteSpace(fieldToolTipsCache[0])))
+                        List<LabelInformation> fieldToolTipsCache = tableToolTipsCache[fieldNameKey];
+                        if ((fieldToolTipsCache.Count > 0) && (!String.IsNullOrWhiteSpace(fieldToolTipsCache[0].Value)))
                         {
-                            string newToolTip = fieldToolTipsCache[0];
+                            var newToolTip = fieldToolTipsCache[0];
 
                             PageFieldSyntax newNode = this.SetPageFieldToolTip(node, newToolTip);
                             if (newNode != null)

--- a/language-server/Shared.AnZwDev.ALTools/CodeTransformations/SetPageFieldToolTipSyntaxRewriter.cs
+++ b/language-server/Shared.AnZwDev.ALTools/CodeTransformations/SetPageFieldToolTipSyntaxRewriter.cs
@@ -12,6 +12,7 @@ namespace AnZwDev.ALTools.CodeTransformations
     {
 
         public string ToolTip { get; set; }
+        public string Comment { get; set; }
 
         public SetPageFieldToolTipSyntaxRewriter()
         {
@@ -21,7 +22,7 @@ namespace AnZwDev.ALTools.CodeTransformations
         {
             if ((!node.ContainsDiagnostics) && (!String.IsNullOrWhiteSpace(this.ToolTip)) && (this.Span != null) && (node.Span.IntersectsWith(this.Span)))
             {
-                PageFieldSyntax newNode = this.SetPageFieldToolTip(node, this.ToolTip);
+                PageFieldSyntax newNode = this.SetPageFieldToolTip(node, this.ToolTip, this.Comment);
                 if (newNode != null)
                 {
                     NoOfChanges++;

--- a/language-server/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
+++ b/language-server/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
@@ -366,9 +366,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Workspace\SymbolsInformation\EnumInformationProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Workspace\SymbolsInformation\InterfaceInformation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Workspace\SymbolsInformation\InterfaceInformationProvider.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Workspace\SymbolsInformation\Internal\IntPageControlWithPropertyValue.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Workspace\SymbolsInformation\Internal\IntPageWithControlsWithPropertyValue.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Workspace\SymbolsInformation\Internal\IntPageControlWithLabelPropertyValue.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Workspace\SymbolsInformation\Internal\IntPageWithControlsWithLabelPropertyValue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Workspace\SymbolsInformation\LabelInformation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Workspace\SymbolsInformation\LabelInformationList_Extensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Workspace\SymbolsInformation\MethodInformation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Workspace\SymbolsInformation\ObjectIdInformationProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Workspace\SymbolsInformation\ObjectIdRangeIdInformationCollection.cs" />

--- a/language-server/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
+++ b/language-server/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
@@ -155,6 +155,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ALSymbols\SymbolReaders\ALSymbolInfoSyntaxTreeReader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ALSymbols\SymbolReaders\ALSyntaxTreeSymbolsReader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ALToolsConst.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CodeCompletion\CodeCompletionParameters.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\AddReferencedTablesPermissionsSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\AddTableDataCaptionFieldsRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\AddDropDownFieldGroupsRewriter.cs" />

--- a/language-server/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/Internal/IntPageControlWithLabelPropertyValue.cs
+++ b/language-server/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/Internal/IntPageControlWithLabelPropertyValue.cs
@@ -4,12 +4,12 @@ using System.Text;
 
 namespace AnZwDev.ALTools.Workspace.SymbolsInformation.Internal
 {
-    internal class IntPageControlWithPropertyValue
+    internal class IntPageControlWithLabelPropertyValue
     {
 
         public string ControlName { get; set; }
         public string ControlSource { get; set; }
-        public string PropertyValue { get; set; }
+        public LabelInformation PropertyValue { get; set; }
 
     }
 }

--- a/language-server/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/Internal/IntPageWithControlsWithLabelPropertyValue.cs
+++ b/language-server/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/Internal/IntPageWithControlsWithLabelPropertyValue.cs
@@ -5,18 +5,18 @@ using System.Text;
 
 namespace AnZwDev.ALTools.Workspace.SymbolsInformation.Internal
 {
-    internal class IntPageWithControlsWithPropertyValue
+    internal class IntPageWithControlsWithLabelPropertyValue
     {
 
         public string Name { get; set; }
         public string SourceTable { get; set; }
         public string PropertyName { get; }
-        public Dictionary<string, IntPageControlWithPropertyValue> Controls { get; }
+        public Dictionary<string, IntPageControlWithLabelPropertyValue> Controls { get; }
 
-        public IntPageWithControlsWithPropertyValue(ALAppPage alAppPage, string propertyName)
+        public IntPageWithControlsWithLabelPropertyValue(ALAppPage alAppPage, string propertyName)
         {
             //get page properties
-            this.Controls = new Dictionary<string, IntPageControlWithPropertyValue>();
+            this.Controls = new Dictionary<string, IntPageControlWithLabelPropertyValue>();
             this.Name = alAppPage.Name;
             this.PropertyName = propertyName;
             if (alAppPage.Properties != null)
@@ -42,19 +42,26 @@ namespace AnZwDev.ALTools.Workspace.SymbolsInformation.Internal
                 string key = alAppControl.Name?.ToLower();
                 if (key != null)
                 {
+                    LabelInformation labelInformation = null;
+                    ALAppProperty property = alAppControl.Properties?.GetProperty(this.PropertyName);
+                    if (property != null)
+                    {
+                        labelInformation = new LabelInformation(PropertyName, property.Value);
+                        labelInformation.Update(alAppControl.Properties);
+                    }
+
                     if (this.Controls.ContainsKey(key))
                     {
-                        ALAppProperty property = alAppControl.Properties?.GetProperty(this.PropertyName);
-                        if ((property != null) && (property.Value != null))
-                            this.Controls[key].PropertyValue = property.Value;
+                        if ((labelInformation != null) && (labelInformation.Value != null))
+                            this.Controls[key].PropertyValue = labelInformation;
                     }
                     else
                     {
-                        this.Controls.Add(key, new IntPageControlWithPropertyValue()
+                        this.Controls.Add(key, new IntPageControlWithLabelPropertyValue()
                         {
                             ControlName = alAppControl.Name,
                             ControlSource = expression,
-                            PropertyValue = alAppControl.Properties?.GetProperty(this.PropertyName)?.Value
+                            PropertyValue = labelInformation
                         });
                     }
                 }

--- a/language-server/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/LabelInformation.cs
+++ b/language-server/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/LabelInformation.cs
@@ -10,13 +10,18 @@ namespace AnZwDev.ALTools.Workspace.SymbolsInformation
     public class LabelInformation
     {
 
-        [JsonProperty("value")]
+        [JsonProperty("value", NullValueHandling = NullValueHandling.Ignore)]
         public string Value { get; set; }
 
-        [JsonProperty("comment")]
+        [JsonProperty("comment", NullValueHandling = NullValueHandling.Ignore)]
         public string Comment { get; set; }
 
         private string _propertyName;
+
+        public LabelInformation()
+        {
+        }
+
         public LabelInformation(string propertyName)
         {
             this._propertyName = propertyName;

--- a/language-server/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/LabelInformationList_Extensions.cs
+++ b/language-server/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/LabelInformationList_Extensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.Workspace.SymbolsInformation
+{
+    public static class LabelInformationList_Extensions
+    {
+
+        public static bool ContainsValue(this List<LabelInformation> elements, string value)
+        {
+            for (int i = 0; i < elements.Count; i++)
+                if (elements[i].Value == value)
+                    return true;
+            return false;
+        }
+
+    }
+}

--- a/language-server/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/TableFieldInformaton.cs
+++ b/language-server/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/TableFieldInformaton.cs
@@ -26,7 +26,7 @@ namespace AnZwDev.ALTools.Workspace.SymbolsInformation
         public string Description { get; set; }
 
         [JsonProperty("toolTips", NullValueHandling = NullValueHandling.Ignore)]
-        public List<string> ToolTips { get; set; }
+        public List<LabelInformation> ToolTips { get; set; }
 
         public TableFieldInformaton()
         {

--- a/language-server/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/TableInformationProvider.cs
+++ b/language-server/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/TableInformationProvider.cs
@@ -168,11 +168,11 @@ namespace AnZwDev.ALTools.Workspace.SymbolsInformation
             {
                 PageInformationProvider pageInformationProvider = new PageInformationProvider();
                 string[] tables = { tableName };
-                Dictionary<string, Dictionary<string, List<string>>> toolTips = pageInformationProvider.CollectTableFieldsToolTips(project, tables, toolTipsSourceDependencies);
+                Dictionary<string, Dictionary<string, List<LabelInformation>>> toolTips = pageInformationProvider.CollectTableFieldsToolTips(project, tables, toolTipsSourceDependencies);
                 string tableKey = tableName.ToLower();
                 if (toolTips.ContainsKey(tableKey))
                 {
-                    Dictionary<string, List<string>> fieldsToolTips = toolTips[tableKey];
+                    Dictionary<string, List<LabelInformation>> fieldsToolTips = toolTips[tableKey];
                     for (int i = 0; i < fields.Count; i++)
                     {
                         string fieldKey = fields[i].Name?.ToLower();

--- a/language-server/Shared.AnZwDev.ALTools/WorkspaceCommands/SetPageFieldToolTipWorkspaceCommand.cs
+++ b/language-server/Shared.AnZwDev.ALTools/WorkspaceCommands/SetPageFieldToolTipWorkspaceCommand.cs
@@ -11,6 +11,7 @@ namespace AnZwDev.ALTools.WorkspaceCommands
     public class SetPageFieldToolTipWorkspaceCommand : SyntaxRewriterWorkspaceCommand<SetPageFieldToolTipSyntaxRewriter>
     {
         public static string ToolTipParameterName = "toolTip";
+        public static string CommentParameterName = "comment";
 
         public SetPageFieldToolTipWorkspaceCommand(ALDevToolsServer alDevToolsServer) : base(alDevToolsServer, "setPageFieldToolTip")
         {
@@ -20,6 +21,7 @@ namespace AnZwDev.ALTools.WorkspaceCommands
         {
             base.SetParameters(sourceCode, projectPath, filePath, span, parameters);
             this.SyntaxRewriter.ToolTip = parameters.GetStringValue(ToolTipParameterName);
+            this.SyntaxRewriter.Comment = parameters.GetStringValue(CommentParameterName);
         }
 
     }

--- a/vscode-extension/htmlresources/altablewizard/altablewizard.html
+++ b/vscode-extension/htmlresources/altablewizard/altablewizard.html
@@ -49,7 +49,22 @@
                         </div>
                     </div>
                 </div>
-    
+
+                <div class="formline">
+                    <div class="formcaption">Data Classification:</div>
+                    <div class="formfield">
+                        <select id="dataclassification" class="fixedopt">
+                            <option value="AccountData">AccountData</option>
+                            <option value="CustomerContent">CustomerContent</option>
+                            <option value="EndUserIdentifiableInformation">EndUserIdentifiableInformation</option>
+                            <option value="EndUserPseudonymousIdentifiers">EndUserPseudonymousIdentifiers</option>
+                            <option value="OrganizationIdentifiableInformation">OrganizationIdentifiableInformation</option>
+                            <option value="SystemMetadata">SystemMetadata</option>
+                            <option value="ToBeClassified">ToBeClassified</option>
+                        </select>
+                    </div>
+                </div>
+
                 <div id="datapercompanyline" class="formline">
                     <div class="formcaption">Data per Company:</div>
                     <div class="formfield">

--- a/vscode-extension/htmlresources/altablewizard/js/altablewizard.js
+++ b/vscode-extension/htmlresources/altablewizard/js/altablewizard.js
@@ -49,6 +49,7 @@ class TableWizard extends BaseObjectWizard {
             //initialize inputs
             document.getElementById("objectid").value = this._data.objectId;
             document.getElementById("objectname").value = this._data.objectName;
+            document.getElementById("dataclassification").value = this._data.dataClassification;
             document.getElementById("datapercompany").checked = this._data.dataPerCompany;
 
             //initialize fields list
@@ -70,6 +71,7 @@ class TableWizard extends BaseObjectWizard {
             data: {
                 objectId : this._data.objectId,
                 objectName : this._data.objectName,
+                dataClassification : this._data.dataClassification,
                 dataPerCompany : this._data.dataPerCompany,
                 fields: this._data.fields
             }
@@ -79,6 +81,7 @@ class TableWizard extends BaseObjectWizard {
     collectStepData(finishSelected) {
         this._data.objectId = document.getElementById("objectid").value;
         this._data.objectName = document.getElementById("objectname").value;
+        this._data.dataClassification = document.getElementById("dataclassification").value;
         this._data.dataPerCompany = document.getElementById("datapercompany").checked;
         this._data.fields = this._fieldsgrid.getData();
     }

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "al-code-outline",
-	"version": "3.0.46",
+	"version": "3.0.47",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
 	"name": "al-code-outline",
 	"displayName": "AZ AL Dev Tools/AL Code Outline",
 	"description": "AZ AL Development Tools: AL code outline, object browser, object creators",
-	"version": "3.0.46",
+	"version": "3.0.47",
 	"publisher": "andrzejzwierzchowski",
 	"engines": {
 		"vscode": "^1.47.0"
@@ -1937,7 +1937,12 @@
 						"uniqueItems": true,
 						"description": "Field names patterns for fields in table DataCaptionFields property created by 'Add Table DataCaptionFields' commands"
 					},
-
+					"alOutline.keepVariableNamesCompletionAffixes": {
+						"type": "boolean",
+						"default": false,
+						"description": "Set to true to keep affixes in variable names suggested by completion providers",
+						"scope": "resource"
+					},
 					"alOutline.completionProviders": {
 						"type": "array",
 						"items": {

--- a/vscode-extension/src/allanguage/alSyntaxWriter.ts
+++ b/vscode-extension/src/allanguage/alSyntaxWriter.ts
@@ -273,7 +273,7 @@ export class ALSyntaxWriter {
             this.encodeName(source));        
     }
 
-    public writeTableField(fieldId: string, fieldName: string, fieldDataType: string, fieldLength: string, dataClassification: string) {
+    public writeTableField(fieldId: string, fieldName: string, fieldDataType: string, fieldLength: string, dataClassification: string | undefined, tableDataClassification: string | undefined) {
         let dataType = fieldDataType.toLowerCase();
         if ((fieldLength) && ((dataType == 'text') || (dataType == 'code')))
             fieldDataType = fieldDataType + '[' + fieldLength + ']';
@@ -288,10 +288,17 @@ export class ALSyntaxWriter {
         this.writeLine("field(" + fieldId + "; " + ALSyntaxHelper.toNameText(fieldName) + "; " + fieldDataType + ")");
         this.writeStartBlock();
         this.writeProperty('Caption', ALSyntaxHelper.toStringText(fieldName));
+
+        
+        if (tableDataClassification) {
+            if ((dataClassification) && (dataClassification === tableDataClassification))
+                dataClassification = undefined;
+        } else if (!dataClassification)
+            dataClassification = 'ToBeClassified';
+
         if (dataClassification)
             this.writeProperty("DataClassification", dataClassification);
-        else
-            this.writeProperty("DataClassification", "ToBeClassified");
+            
         this.writeEndBlock();
     }
 

--- a/vscode-extension/src/allanguage/alSyntaxWriter.ts
+++ b/vscode-extension/src/allanguage/alSyntaxWriter.ts
@@ -4,6 +4,7 @@ import { StringHelper } from '../tools/stringHelper';
 import { NameValue } from '../tools/nameValue';
 import { AppAreaMode } from '../alsyntaxmodifiers/appAreaMode';
 import { ApiFieldNameConversion } from './apiFieldNameConversion';
+import { LabelInformation } from '../symbolsinformation/labelInformation';
 
 export class ALSyntaxWriter {
     private content : string;
@@ -302,7 +303,7 @@ export class ALSyntaxWriter {
         this.writeEndBlock();
     }
 
-    public writePageField(fieldName : string, fieldCaption: string | undefined, fieldCaptionComment: string | undefined, fieldDescription: string | undefined, createToolTip: boolean, existingToolTips: string[] | undefined) {
+    public writePageField(fieldName : string, fieldCaption: string | undefined, fieldCaptionComment: string | undefined, fieldDescription: string | undefined, createToolTip: boolean, existingToolTips: LabelInformation[] | undefined) {
         this.writeStartNameSourceBlock("field", this.encodeName(fieldName), 'Rec.' + this.encodeName(fieldName));
         if (this.applicationAreaMode == AppAreaMode.addToAllControls)
             this.writeApplicationArea();
@@ -336,13 +337,16 @@ export class ALSyntaxWriter {
             this.writeProperty("ApplicationArea", this.applicationArea);
     }
 
-    public writeTooltip(captionTemplate: string, commentTemplate: string, value: string | undefined, comment: string | undefined, fieldDescription: string | undefined, existingToolTips: string[] | undefined) {
+    public writeTooltip(captionTemplate: string, commentTemplate: string, value: string | undefined, comment: string | undefined, fieldDescription: string | undefined, existingToolTips: LabelInformation[] | undefined) {
         let textValue: string | undefined = undefined;
 
         if ((this.useTableFieldDescriptionAsToolTip) && (fieldDescription) && (fieldDescription != ""))
             textValue = this.encodeString(fieldDescription);
-        else if ((existingToolTips) && (existingToolTips.length > 0) && (existingToolTips[0]) && (existingToolTips[0] != ""))
-            textValue = this.encodeString(existingToolTips[0]);
+        else if ((existingToolTips) && (existingToolTips.length > 0) && (existingToolTips[0].value) && (existingToolTips[0].value !== "")) {
+            textValue = this.encodeString(existingToolTips[0].value);
+            if ((existingToolTips[0].comment) && (existingToolTips[0].comment !== ""))
+                textValue = textValue + ", Comment = " + this.encodeString(existingToolTips[0].comment);
+        }
         else if ((captionTemplate) && (captionTemplate != "") && (value) && (value != "")) {
             textValue = this.applyCaptionTemplate(captionTemplate, value, comment);
             let commentValue = this.applyCaptionTemplate(commentTemplate, value, comment);

--- a/vscode-extension/src/codeactions/alReuseToolTipCodeCommand.ts
+++ b/vscode-extension/src/codeactions/alReuseToolTipCodeCommand.ts
@@ -41,12 +41,11 @@ export class ALReuseToolTipCodeCommand extends ALCodeAction {
                         command: "azALDevTools.ReuseToolTipFromOtherPages",
                         title: "Reuse tooltip from other pages",
                         arguments: [document, symbol]
-                    }
+                    };
                     actions.push(action);
                 }
 
             }
         }
     }
-
 }

--- a/vscode-extension/src/editorextensions/alCompletionProvider.ts
+++ b/vscode-extension/src/editorextensions/alCompletionProvider.ts
@@ -18,13 +18,15 @@ export class ALCompletionProvider implements vscode.CompletionItemProvider {
         if (document.uri?.fsPath) {
             let configuration = vscode.workspace.getConfiguration('alOutline', document.uri);
             let completionProviders = configuration.get<string[]>('completionProviders');
+            let keepVariableNamesAffixes = !!configuration.get<boolean>('keepVariableNamesCompletionAffixes');
 
             if ((completionProviders) && (completionProviders.length > 0)) {
                 await this._context.activeDocumentSymbols.loadAsync(false);
 
                 let textPosition = new TextPosition();
                 textPosition.set(position.line, position.character);
-                let request = new ToolsCodeCompletionRequest(textPosition, document.uri.fsPath, completionProviders);
+                let request = new ToolsCodeCompletionRequest(textPosition, document.uri.fsPath, completionProviders, { 
+                    keepVariableNamesAffixes: keepVariableNamesAffixes });
                 let response = await this._context.toolsLangServerClient.codeCompletion(request);
                 
                 if ((response) && (response.completionItems)) {

--- a/vscode-extension/src/langserver/codeCompletion/toolsCodeCompletionParameters.ts
+++ b/vscode-extension/src/langserver/codeCompletion/toolsCodeCompletionParameters.ts
@@ -1,0 +1,3 @@
+export interface ToolsCodeCompletionParameters {
+    keepVariableNamesAffixes: boolean;
+}

--- a/vscode-extension/src/langserver/codeCompletion/toolsCodeCompletionRequest.ts
+++ b/vscode-extension/src/langserver/codeCompletion/toolsCodeCompletionRequest.ts
@@ -1,15 +1,18 @@
 import { TextPosition } from "../../symbollibraries/textPosition";
+import { ToolsCodeCompletionParameters } from "./toolsCodeCompletionParameters";
 
 export class ToolsCodeCompletionRequest {
     
     position: TextPosition;
-    path: string;
+    path: string;    
     providers: string[];
+    parameters: ToolsCodeCompletionParameters;
 
-    constructor(newPosition: TextPosition, newPath: string, newProviders: string[]) {
+    constructor(newPosition: TextPosition, newPath: string, newProviders: string[], newParameters: ToolsCodeCompletionParameters) {
         this.position = newPosition;
         this.path = newPath;
         this.providers = newProviders;
+        this.parameters = newParameters;
     }
 
 }

--- a/vscode-extension/src/langserver/symbolsinformation/toolsGetPageFieldAvailableToolTipsResponse.ts
+++ b/vscode-extension/src/langserver/symbolsinformation/toolsGetPageFieldAvailableToolTipsResponse.ts
@@ -1,3 +1,5 @@
+import { LabelInformation } from "../../symbolsinformation/labelInformation";
+
 export class ToolsGetPageFieldAvailableToolTipsResponse {
-    toolTips: string[] | undefined;
+    toolTips: LabelInformation[] | undefined;
 }

--- a/vscode-extension/src/objectwizards/syntaxbuilders/alTableExtSyntaxBuilder.ts
+++ b/vscode-extension/src/objectwizards/syntaxbuilders/alTableExtSyntaxBuilder.ts
@@ -17,7 +17,7 @@ export class ALTableExtSyntaxBuilder {
 
         for (let i = 0; i < data.fields.length; i++) {
             writer.writeTableField(data.fields[i].id, data.fields[i].name, data.fields[i].type, data.fields[i].length,
-                data.fields[i].dataClassification);
+                data.fields[i].dataClassification, undefined);
         }
 
         writer.writeEndFields();

--- a/vscode-extension/src/objectwizards/syntaxbuilders/alTableSyntaxBuilder.ts
+++ b/vscode-extension/src/objectwizards/syntaxbuilders/alTableSyntaxBuilder.ts
@@ -13,7 +13,11 @@ export class ALTableSyntaxBuilder {
 
         writer.writeStartObject("table", data.objectId, data.objectName);
         writer.addProperty("Caption", writer.encodeString(ALSyntaxHelper.removePrefixSuffix(data.objectName, data.projectSettings)));
-        writer.addProperty("DataClassification", "ToBeClassified");
+
+        if (data.dataClassification)
+            writer.addProperty("DataClassification", data.dataClassification);
+        else
+            writer.addProperty("DataClassification", "ToBeClassified");
         if (!data.dataPerCompany)
             writer.addProperty("DataPerCompany", "false");
         writer.writeProperties();
@@ -24,7 +28,7 @@ export class ALTableSyntaxBuilder {
 
         for (let i=0; i<data.fields.length; i++) {
             writer.writeTableField(data.fields[i].id, data.fields[i].name, data.fields[i].type, data.fields[i].length,
-                data.fields[i].dataClassification);
+                data.fields[i].dataClassification, data.dataClassification);
         }
 
         writer.writeEndFields();

--- a/vscode-extension/src/objectwizards/wizards/alTableWizardData.ts
+++ b/vscode-extension/src/objectwizards/wizards/alTableWizardData.ts
@@ -6,11 +6,13 @@ export class ALTableWizardData extends ALObjectWizardData {
     objectName : string;
     dataPerCompany : boolean;
     fields: ALTableWizardFieldData[];
+    dataClassification: string | undefined;
     projectSettings: ToolsGetProjectSettingsResponse | undefined;
 
     constructor() {
         super();
         this.objectName = '';
+        this.dataClassification = "ToBeClassified";
         this.dataPerCompany = true;
         this.fields = [];
         this.projectSettings = undefined;

--- a/vscode-extension/src/objectwizards/wizards/alTableWizardPage.ts
+++ b/vscode-extension/src/objectwizards/wizards/alTableWizardPage.ts
@@ -39,6 +39,7 @@ export class ALTableWizardPage extends ProjectItemWizardPage {
         //build parameters
         this._tableWizardData.objectId = data.objectId;
         this._tableWizardData.objectName = data.objectName;
+        this._tableWizardData.dataClassification = data.dataClassification;
         this._tableWizardData.dataPerCompany = !!data.dataPerCompany;
         this._tableWizardData.fields = WizardTableFieldHelper.validateFields(data.fields);
     

--- a/vscode-extension/src/symbolsinformation/tableFieldInformation.ts
+++ b/vscode-extension/src/symbolsinformation/tableFieldInformation.ts
@@ -9,6 +9,6 @@ export class TableFieldInformation extends SymbolWithIdInformation {
     state: TableFieldState | undefined;
     captionLabel: LabelInformation | undefined;
     description: string | undefined;
-    toolTips: string[] | undefined;
+    toolTips: LabelInformation[] | undefined;
     uiDesc: string | undefined;
 }

--- a/vscode-extension/src/tools/templateQuickPickItem.ts
+++ b/vscode-extension/src/tools/templateQuickPickItem.ts
@@ -1,0 +1,13 @@
+import * as vscode from 'vscode';
+
+export class TemplateQuickPickItem<T> implements vscode.QuickPickItem {
+    label: string;    
+    picked?: boolean | undefined;
+    value: T;
+
+    constructor(newLabel: string, newValue: T, newPicked: boolean) {
+        this.label = newLabel;
+        this.value = newValue;
+        this.picked = newPicked;
+    }
+}


### PR DESCRIPTION
 - Issue #470 - Add "DataClassification" as table property to the "New Table Wizard"
 - Issue #472 - CodeCompletion - Do not Ignore Prefix in variable names
   - new alOutline.keepVariableNamesCompletionAffixes setting added
 - Issue #473 - When reusing tooltip from another page, include the tooltip comment
 - Issue #474 - Remove with usage on codeunits with TableNo
 - Linux version