### PR TITLE
13.67.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 13.67.0
+ - Issue #535 - Separate 'Sort Triggers' action - sorting fixes and improvements
+
+Thank you
+ - fvet and TKapitan for testing and adding comments to the issue #535
+
 ## 13.66.0
  - Fix Identifiers case command incorrectly detected object IDs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  - Issue #590 - Delete unused variables with obsolete tag 
    - "Remove global variables" settings split into separate "Remove global variables" and "Remove protected global variables" settings
      - `removeProtectedGlobalVariables` property added to the `defaultRemoveUnusedVariablesSetting` setting
+ - Issue #591 - Limit Enum Object Names to 30 Chars in AL File Wizard
  - Issue #592 - Remove redundant ApplicationArea adds unnecessary quotes 
 
  `alOutline.defaultRemoveUnusedVariablesSettings`: default settings for the RemoveUnusedVariables command when run by the Code Cleanup, these properties can be set:
@@ -14,6 +15,7 @@
 Thank you
  - fvet and TKapitan for testing and adding comments to the issue #535
  - ThorstenEngelsGOB for reporting issue #590
+ - mjmatthiesen for reporting issue #591
  - dannoe for reporting issue #592
 
 ## 13.66.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@
  - Issue #591 - Limit Enum Object Names to 30 Chars in AL File Wizard
  - Issue #592 - Remove redundant ApplicationArea adds unnecessary quotes 
 
- `alOutline.defaultRemoveUnusedVariablesSettings`: default settings for the RemoveUnusedVariables command when run by the Code Cleanup, these properties can be set:
-  * `removeGlobalVariables`: remove global variables
-  * `removeProtectedGlobalVariables`: remove protected global variables
-
 Thank you
  - fvet and TKapitan for testing and adding comments to the issue #535
  - ThorstenEngelsGOB for reporting issue #590

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,18 @@
 
 ## 13.67.0
  - Issue #535 - Separate 'Sort Triggers' action - sorting fixes and improvements
- - Issue #592 - Remove redundant ApplicationArea adds unnecessary quotes
+ - Issue #590 - Delete unused variables with obsolete tag 
+   - "Remove global variables" settings split into separate "Remove global variables" and "Remove protected global variables" settings
+     - `removeProtectedGlobalVariables` property added to the `defaultRemoveUnusedVariablesSetting` setting
+ - Issue #592 - Remove redundant ApplicationArea adds unnecessary quotes 
+
+ `alOutline.defaultRemoveUnusedVariablesSettings`: default settings for the RemoveUnusedVariables command when run by the Code Cleanup, these properties can be set:
+  * `removeGlobalVariables`: remove global variables
+  * `removeProtectedGlobalVariables`: remove protected global variables
 
 Thank you
  - fvet and TKapitan for testing and adding comments to the issue #535
+ - ThorstenEngelsGOB for reporting issue #590
  - dannoe for reporting issue #592
 
 ## 13.66.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## 13.67.0
  - Issue #535 - Separate 'Sort Triggers' action - sorting fixes and improvements
+ - Issue #592 - Remove redundant ApplicationArea adds unnecessary quotes
 
 Thank you
  - fvet and TKapitan for testing and adding comments to the issue #535
+ - dannoe for reporting issue #592
 
 ## 13.66.0
  - Fix Identifiers case command incorrectly detected object IDs

--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ This extension contributes the following settings:
   * `setLabelsCaptions`: set labels captions
 * `alOutline.defaultRemoveUnusedVariablesSettings`: default settings for the RemoveUnusedVariables command when run by the Code Cleanup, these properties can be set:
   * `removeGlobalVariables`: remove global variables
+  * `removeProtectedGlobalVariables`: remove protected global variables
   * `removeLocalVariables`: remove local variables
   * `removeLocalMethodParameters`: remove local methods parameters
 * `alOutline.defaultRemoveEmptyTriggersSettings`: default settings for the RemoveEmptyTriggers command when run by the Code Cleanup, these properties can be set:

--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ This extension contributes the following settings:
 * `alOutline.additionalMandatoryAffixesPatterns`: Additional list of name affixes patterns, '?' can be used for matching any character. These values are used to remove affixes from names in code actions, commands and code completion
 * `alOutline.dropDownGroupFieldsNamesPatterns`: array of string patters for table DropDown group fields created by "Add DropDown FieldGroups..." commands, you can use "*" for partial name matching, first found field for each setting entry will be used
 * `alOutline.tableDataCaptionFieldsNamesPatterns`: array of string patters for field names for table DataCaptionFields property created by "Add Table DataCaptionFields..." commands, you can use "*" for partial name matching, first found field for each setting entry will be used
+* `alOutline.sortMembersPutGlobalVariablesAfterTriggers` - defines how global variables section is sorted by "Sort Procedures" command. If set to `true` (default), global variables section is put after triggers, if set to `false` it will be first.
 * `alOutline.triggersSortMode` - defines how "sort procedures" and "sort triggers" commands are sorting triggers, one of these values can be used:
   * `None` - triggers won't be sorted, this is the default value for sort procedures
   * `Name` - triggers will be sorted by name

--- a/README.md
+++ b/README.md
@@ -364,7 +364,10 @@ This extension contributes the following settings:
 * `alOutline.additionalMandatoryAffixesPatterns`: Additional list of name affixes patterns, '?' can be used for matching any character. These values are used to remove affixes from names in code actions, commands and code completion
 * `alOutline.dropDownGroupFieldsNamesPatterns`: array of string patters for table DropDown group fields created by "Add DropDown FieldGroups..." commands, you can use "*" for partial name matching, first found field for each setting entry will be used
 * `alOutline.tableDataCaptionFieldsNamesPatterns`: array of string patters for field names for table DataCaptionFields property created by "Add Table DataCaptionFields..." commands, you can use "*" for partial name matching, first found field for each setting entry will be used
-* `alOutline.sortMembersPutGlobalVariablesAfterTriggers` - defines how global variables section is sorted by "Sort Procedures" command. If set to `true` (default), global variables section is put after triggers, if set to `false` it will be first.
+* `alOutline.sortMembersGlobalVariablesSortMode` - defines how "sort procedures" and "sort triggers" commands are sorting global variables sections, one of these values can be used:
+  * `First` - global variables sections are first
+  * `AfterTriggers` - global variables sections are after triggers and before procedures, this is the default value
+  * `Last` - global variables sections are at the bottom of the file
 * `alOutline.triggersSortMode` - defines how "sort procedures" and "sort triggers" commands are sorting triggers, one of these values can be used:
   * `None` - triggers won't be sorted, this is the default value for sort procedures
   * `Name` - triggers will be sorted by name

--- a/language-server/AZALDevToolsTestConsoleApp/Program.cs
+++ b/language-server/AZALDevToolsTestConsoleApp/Program.cs
@@ -108,7 +108,8 @@ namespace AZALDevToolsTestConsoleApp
 
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\SmallBC23\\SortProceduresTests.Codeunit.al";
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\SmallBC23\\InterfaceDemo.Interface.al";
-            filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\SmallBC23\\DemoPage.Page.al";
+            //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\SmallBC23\\DemoPage.Page.al";
+            filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\SmallBC23\\SortingTestPage.Page.al";
 
             string content = FileUtils.SafeReadAllText(filePath);
             Dictionary<string, string> pm = new();
@@ -126,6 +127,10 @@ namespace AZALDevToolsTestConsoleApp
             pm.Add("includeInterfaces", "true");
 
             pm.Add("reuseToolTips", "true");
+
+            //pm.Add("triggersSortMode", "NaturalOrder");
+            pm.Add("sortSingleNodeRegions", "true");
+            //pm.Add("triggersNaturalOrder", "");
 
             ALProject project = host.ALDevToolsServer.Workspace.Projects[0];
 
@@ -164,8 +169,8 @@ namespace AZALDevToolsTestConsoleApp
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("addReferencedTablesPermissions", content, projects[0].folderPath, filePath, null, pm, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("generateCSVXmlPortHeaders", content, projects[0].folderPath, filePath, null, pm, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeRedundantDataClassification", content, projects[0].folderPath, filePath, null, pm, null);
-            //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("sortProcedures", content, projects[0].folderPath, filePath, null, pm, null);
-            WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("fixIdentifiersCase", content, projects[0].folderPath, filePath, null, pm, null, null);
+            WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("sortProcedures", content, projects[0].folderPath, filePath, null, pm, null, null);
+            //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("fixIdentifiersCase", content, projects[0].folderPath, filePath, null, pm, null, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("oneStatementPerLine", content, projects[0].folderPath, filePath, null, pm, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("addMissingCaseLines", content, projects[0].folderPath, filePath, null, pm, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("addTooTipsEndingDots", content, projects[0].folderPath, filePath, null, pm, null);

--- a/language-server/AZALDevToolsTestConsoleApp/Program.cs
+++ b/language-server/AZALDevToolsTestConsoleApp/Program.cs
@@ -109,7 +109,8 @@ namespace AZALDevToolsTestConsoleApp
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\SmallBC23\\SortProceduresTests.Codeunit.al";
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\SmallBC23\\InterfaceDemo.Interface.al";
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\SmallBC23\\DemoPage.Page.al";
-            filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\SmallBC23\\SortingTestPage.Page.al";
+            //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\SmallBC23\\SortingTestPage.Page.al";
+            filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\SmallBC23\\MyTestPage.Page.al";
 
             string content = FileUtils.SafeReadAllText(filePath);
             Dictionary<string, string> pm = new();
@@ -164,13 +165,13 @@ namespace AZALDevToolsTestConsoleApp
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeEmptyLines", content, projects[0].folderPath, filePath, null, pm, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeEmptySections", content, projects[0].folderPath, filePath, null, pm, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeStrSubstNoFromError", content, projects[0].folderPath, filePath, null, pm, null);
-            //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeRedundantAppAreas", content, projects[0].folderPath, filePath, null, pm, null);
+            WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeRedundantAppAreas", content, projects[0].folderPath, filePath, null, pm, null, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("addTableDataCaptionFields", content, projects[0].folderPath, filePath, null, pm, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("addDropDownFieldGroups", content, projects[0].folderPath, filePath, null, pm, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("addReferencedTablesPermissions", content, projects[0].folderPath, filePath, null, pm, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("generateCSVXmlPortHeaders", content, projects[0].folderPath, filePath, null, pm, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeRedundantDataClassification", content, projects[0].folderPath, filePath, null, pm, null);
-            WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("sortProcedures", content, projects[0].folderPath, filePath, null, pm, null, null);
+            //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("sortProcedures", content, projects[0].folderPath, filePath, null, pm, null, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("fixIdentifiersCase", content, projects[0].folderPath, filePath, null, pm, null, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("oneStatementPerLine", content, projects[0].folderPath, filePath, null, pm, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("addMissingCaseLines", content, projects[0].folderPath, filePath, null, pm, null);

--- a/language-server/AZALDevToolsTestConsoleApp/Program.cs
+++ b/language-server/AZALDevToolsTestConsoleApp/Program.cs
@@ -122,6 +122,7 @@ namespace AZALDevToolsTestConsoleApp
             pm.Add("removeLocalMethodParameters", "true");
 
             pm.Add("triggersSortMode", "NaturalOrder");
+            pm.Add("globalVariablesSortMode", "First");
             pm.Add("triggersNaturalOrder", "[]");
 
             pm.Add("includeInterfaces", "true");

--- a/language-server/Shared.AnZwDev.ALTools/CodeTransformations/RemoveUnusedVariablesSyntaxRewriter.cs
+++ b/language-server/Shared.AnZwDev.ALTools/CodeTransformations/RemoveUnusedVariablesSyntaxRewriter.cs
@@ -15,6 +15,7 @@ namespace AnZwDev.ALTools.CodeTransformations
     public class RemoveUnusedVariablesSyntaxRewriter : ALSemanticModelSyntaxRewriter
     {
         public bool RemoveGlobalVariables { get; set; }
+        public bool RemoveProtectedGlobalVariables { get; set; }
         public bool RemoveLocalVariables { get; set; }
         public bool RemoveLocalMethodParameters { get; set; }
         public bool IgnoreCodeAnalysisRules { get; set; }
@@ -27,6 +28,7 @@ namespace AnZwDev.ALTools.CodeTransformations
             this.RemoveGlobalVariables = true;
             this.RemoveLocalVariables = true;
             this.RemoveLocalMethodParameters = true;
+            this.RemoveProtectedGlobalVariables = true;
         }
 
         public override SyntaxNode Visit(SyntaxNode node)
@@ -42,7 +44,10 @@ namespace AnZwDev.ALTools.CodeTransformations
 
         public override SyntaxNode VisitGlobalVarSection(GlobalVarSectionSyntax node)
         {
-            if (this.RemoveGlobalVariables)
+            var accessModifier = node.AccessModifier.ValueText;
+            var isProtected = (accessModifier != null) && (accessModifier.Trim().ToLower() == "protected");
+           
+            if ((this.RemoveGlobalVariables && (!isProtected)) || (this.RemoveProtectedGlobalVariables && isProtected))
             {
                 var appObject = node.FindParentApplicationObject();
                 if (appObject != null)

--- a/language-server/Shared.AnZwDev.ALTools/CodeTransformations/SortProceduresGlobalVariablesSortMode.cs
+++ b/language-server/Shared.AnZwDev.ALTools/CodeTransformations/SortProceduresGlobalVariablesSortMode.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.CodeTransformations
+{
+    public enum SortProceduresGlobalVariablesSortMode
+    {
+
+        First = 0,
+        AfterTriggers = 1,
+        Last = 2
+
+    }
+}

--- a/language-server/Shared.AnZwDev.ALTools/Core/UniqueStringList.cs
+++ b/language-server/Shared.AnZwDev.ALTools/Core/UniqueStringList.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace AnZwDev.ALTools.Core
+{
+    public class UniqueStringList
+    {
+
+        public static bool IsNullOrEmpty(UniqueStringList list)
+        {
+            return ((list == null) || (list.Count == 0));
+        }
+
+
+        private List<string> _values = new List<string>();
+        private HashSet<string> _uniqueValues = new HashSet<string>();
+
+        public string this[int index]
+        {
+            get { return _values[index]; }
+        }
+
+        public int Count
+        {
+            get { return _values.Count; }
+        }
+
+        public UniqueStringList()
+        {
+        }
+
+        public void Add(string value)
+        {
+            if (!String.IsNullOrWhiteSpace(value))
+            {
+                string key = GetKey(value);
+                if (!_uniqueValues.Contains(key))
+                {
+                    _values.Add(value);
+                    _uniqueValues.Add(key);
+                }
+            }
+        }
+
+        public bool Contains(string value)
+        {
+            string key = GetKey(value);
+            return _uniqueValues.Contains(key);
+        }
+
+        private string GetKey(string value)
+        {
+            return value.ToLower();
+        }
+
+        public bool Equals(UniqueStringList list)
+        {
+            if ((list == null) || (this.Count != list.Count))
+                return false;
+
+            for (int i = 0; i < list.Count; i++)
+                if (!Contains(list[i]))
+                    return false;
+
+            return true;
+        }
+
+    }
+}

--- a/language-server/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
+++ b/language-server/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
@@ -241,6 +241,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\RemoveEventPublishersSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\RemoveRedundantDataClassificationSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\OneStatementPerLineSyntaxRewriter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\SortProceduresGlobalVariablesSortMode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\SortProceduresTriggerSortMode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\TriggersOrder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\TriggersOrderCollection.cs" />

--- a/language-server/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
+++ b/language-server/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
@@ -250,6 +250,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Core\FullyQualifiedNameComparer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\NullableStringComparer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\StringArrayComparer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\UniqueStringList.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\CompilationUnitSyntaxExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\ConvertedSyntaxKindExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\ListExtensions.cs" />

--- a/language-server/Shared.AnZwDev.ALTools/WorkspaceCommands/RemoveUnusedVariablesWorkspaceCommand.cs
+++ b/language-server/Shared.AnZwDev.ALTools/WorkspaceCommands/RemoveUnusedVariablesWorkspaceCommand.cs
@@ -16,6 +16,7 @@ namespace AnZwDev.ALTools.WorkspaceCommands
     {
 
         public static string RemoveGlobalVariablesParameterName = "removeGlobalVariables";
+        public static string RemoveProtectedGlobalVariablesParameterName = "removeProtectedGlobalVariables";
         public static string RemoveLocalVariablesParameterName = "removeLocalVariables";
         public static string RemoveLocalMethodParametersParameterName = "removeLocalMethodParameters";
 
@@ -27,6 +28,8 @@ namespace AnZwDev.ALTools.WorkspaceCommands
         {
             base.SetParameters(syntaxTree, node, semanticModel, project, span, parameters);
             this.SyntaxRewriter.RemoveGlobalVariables = parameters.GetBoolValue(RemoveGlobalVariablesParameterName);
+            this.SyntaxRewriter.RemoveProtectedGlobalVariables = parameters.GetBoolValue(RemoveProtectedGlobalVariablesParameterName);
+
             this.SyntaxRewriter.RemoveLocalVariables = parameters.GetBoolValue(RemoveLocalVariablesParameterName);
             this.SyntaxRewriter.RemoveLocalMethodParameters = parameters.GetBoolValue(RemoveLocalMethodParametersParameterName);
         }

--- a/language-server/Shared.AnZwDev.ALTools/WorkspaceCommands/SortProceduresOrTriggersWorkspaceCommand.cs
+++ b/language-server/Shared.AnZwDev.ALTools/WorkspaceCommands/SortProceduresOrTriggersWorkspaceCommand.cs
@@ -1,4 +1,5 @@
-﻿using AnZwDev.ALTools.CodeTransformations;
+﻿using AnZwDev.ALTools.ALSymbols;
+using AnZwDev.ALTools.CodeTransformations;
 using AnZwDev.ALTools.Extensions;
 using AnZwDev.ALTools.Workspace;
 using AnZwDev.ALTools.WorkspaceCommands.Parameters;
@@ -13,9 +14,9 @@ namespace AnZwDev.ALTools.WorkspaceCommands
     {
 
         public static string TriggersSortModeParameterName = "triggersSortMode";
+        public static string GlobalVariablesSortModeParameterName = "globalVariablesSortMode";
         public static string TriggersNaturalOrderParameterName = "triggersNaturalOrder";
         public static string SortSingleNodeRegionsParameterName = "sortSingleNodeRegions";
-        public static string GlobalVariablesAfterTriggersParameterName = "globalVariablesAfterTriggers";
 
         public SortProceduresOrTriggersWorkspaceCommand(ALDevToolsServer alDevToolsServer, string name) : base(alDevToolsServer, name)
         {
@@ -28,6 +29,9 @@ namespace AnZwDev.ALTools.WorkspaceCommands
             if (parameters.ContainsKey(TriggersSortModeParameterName))
                 this.SyntaxRewriter.TriggerSortMode = parameters.GetEnumValue(TriggersSortModeParameterName, SortProceduresTriggerSortMode.None);
 
+            if (parameters.ContainsKey(GlobalVariablesSortModeParameterName))
+                this.SyntaxRewriter.GlobalVariablesSortMode = parameters.GetEnumValue(GlobalVariablesSortModeParameterName, SortProceduresGlobalVariablesSortMode.AfterTriggers);
+
             if (parameters.ContainsKey(TriggersNaturalOrderParameterName))
             {
                 var triggersOrder = parameters.GetJsonValue<TriggersOrderParameter[]>(TriggersNaturalOrderParameterName);
@@ -37,7 +41,6 @@ namespace AnZwDev.ALTools.WorkspaceCommands
             }
 
             this.SyntaxRewriter.SortSingleNodeRegions = parameters.GetBoolValue(SortSingleNodeRegionsParameterName);
-            this.SyntaxRewriter.GlobalVariablesAfterTriggers = parameters.GetBoolValue(GlobalVariablesAfterTriggersParameterName);
         }
     }
 }

--- a/language-server/Shared.AnZwDev.ALTools/WorkspaceCommands/SortProceduresOrTriggersWorkspaceCommand.cs
+++ b/language-server/Shared.AnZwDev.ALTools/WorkspaceCommands/SortProceduresOrTriggersWorkspaceCommand.cs
@@ -15,6 +15,7 @@ namespace AnZwDev.ALTools.WorkspaceCommands
         public static string TriggersSortModeParameterName = "triggersSortMode";
         public static string TriggersNaturalOrderParameterName = "triggersNaturalOrder";
         public static string SortSingleNodeRegionsParameterName = "sortSingleNodeRegions";
+        public static string GlobalVariablesAfterTriggersParameterName = "globalVariablesAfterTriggers";
 
         public SortProceduresOrTriggersWorkspaceCommand(ALDevToolsServer alDevToolsServer, string name) : base(alDevToolsServer, name)
         {
@@ -36,6 +37,7 @@ namespace AnZwDev.ALTools.WorkspaceCommands
             }
 
             this.SyntaxRewriter.SortSingleNodeRegions = parameters.GetBoolValue(SortSingleNodeRegionsParameterName);
+            this.SyntaxRewriter.GlobalVariablesAfterTriggers = parameters.GetBoolValue(GlobalVariablesAfterTriggersParameterName);
         }
     }
 }

--- a/vscode-extension/htmlresources/alenumwizard/js/alenumwizard.js
+++ b/vscode-extension/htmlresources/alenumwizard/js/alenumwizard.js
@@ -8,7 +8,13 @@ class EnumWizard extends BaseObjectWizard {
         super.setData(data);
         //initialize fields
         document.getElementById("objectid").value = this._data.objectId;
-        document.getElementById("objectname").value = this._data.objectName;
+        
+        let objectNameFld = document.getElementById("objectname");        
+        objectNameFld.value = this._data.objectName;
+        if (this._data.limitNameLength) {
+            objectNameFld.maxLength = 30;
+        }
+
         document.getElementById("valuelist").value = this._data.valueList;
         document.getElementById("captionlist").value = this._data.captionList;
         document.getElementById("extensible").checked = this._data.extensible;

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "al-code-outline",
-	"version": "13.66.0",
+	"version": "13.67.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1925,6 +1925,22 @@
 						"description": "Specifies how variables are sorted by `Sort Variables` commands.",
 						"scope": "resource"
 					},
+					"alOutline.sortMembersGlobalVariablesSortMode": {
+						"type": "string",
+						"enum": [
+							"First",
+							"AfterTriggers",
+							"Last"
+						],
+						"enumDescriptions": [
+							"First",
+							"Between triggers and procedures",
+							"Last"
+						],
+						"default": "AfterTriggers",
+						"description": "Specifies how global variables sections are sorted by `Sort Procedures` commands.",
+						"scope": "resource"
+					},
 					"alOutline.triggersSortMode": {
 						"type": "string",
 						"enum": [
@@ -2019,12 +2035,6 @@
 						"type": "boolean",
 						"default": false,
 						"description": "Set to true to sort regions containing single element (e.g. regions with single procedures by `Sort Procedures` command).",
-						"scope": "resource"
-					},
-					"alOutline.sortMembersPutGlobalVariablesAfterTriggers": {
-						"type": "boolean",
-						"default": true,
-						"description": "Set to true to put global variables after triggers in `Sort Procedures` commands. Set to false to put them before triggers.",
 						"scope": "resource"
 					},
 					"alOutline.dropDownGroupFieldsNamesPatterns": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
 	"name": "al-code-outline",
 	"displayName": "AZ AL Dev Tools/AL Code Outline",
 	"description": "AZ AL Development Tools: AL code outline, object browser, object creators",
-	"version": "13.66.0",
+	"version": "13.67.0",
 	"publisher": "andrzejzwierzchowski",
 	"engines": {
 		"vscode": "^1.85.0"
@@ -2019,6 +2019,12 @@
 						"type": "boolean",
 						"default": false,
 						"description": "Set to true to sort regions containing single element (e.g. regions with single procedures by `Sort Procedures` command).",
+						"scope": "resource"
+					},
+					"alOutline.sortMembersPutGlobalVariablesAfterTriggers": {
+						"type": "boolean",
+						"default": true,
+						"description": "Set to true to put global variables after triggers in `Sort Procedures` commands. Set to false to put them before triggers.",
 						"scope": "resource"
 					},
 					"alOutline.dropDownGroupFieldsNamesPatterns": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1579,6 +1579,10 @@
 								"type": "boolean",
 								"description": "Remove global variables"
 							},
+							"removeProtectedGlobalVariables": {
+								"type": "boolean",
+								"description": "Remove protected global variables"
+							},
 							"removeLocalVariables": {
 								"type": "boolean",
 								"description": "Remove local variables"

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1396,6 +1396,12 @@
 			{
 				"title": "AZ AL Dev Tools/AL Code Outline",
 				"properties": {
+					"alOutline.limitEnumNameLength" : {
+						"type": "boolean",
+						"default": false,
+						"scope": "resource",
+						"description": "Limit length of enum names to 30 characters in the enum wizard"
+					},
 					"alOutline.docCommentsType": {
 						"type": "string",
 						"default": "xml",

--- a/vscode-extension/src/alsyntaxmodifiers/iRemoveUnusedVariablesSettings.ts
+++ b/vscode-extension/src/alsyntaxmodifiers/iRemoveUnusedVariablesSettings.ts
@@ -1,5 +1,6 @@
 export interface IRemoveUnusedVariablesSettings {
     removeGlobalVariables: boolean | undefined;
+    removeProtectedGlobalVariables: boolean | undefined;
     removeLocalVariables: boolean | undefined;
     removeLocalMethodParameters: boolean | undefined;
 }

--- a/vscode-extension/src/alsyntaxmodifiers/removeUnusedVariablesModifier.ts
+++ b/vscode-extension/src/alsyntaxmodifiers/removeUnusedVariablesModifier.ts
@@ -11,6 +11,7 @@ export class RemoveUnusedVariablesModifier extends WorkspaceCommandSyntaxModifie
         super(context, "Remove Unused Variables", "removeUnusedVariables");
         this._variableTypes = {
             removeGlobalVariables: false,
+            removeProtectedGlobalVariables: false,
             removeLocalVariables: false,
             removeLocalMethodParameters: false
         };
@@ -25,22 +26,32 @@ export class RemoveUnusedVariablesModifier extends WorkspaceCommandSyntaxModifie
     protected areSettingsEmpty(value: IRemoveUnusedVariablesSettings | undefined) {
         return ((!value) || (
             (!value.removeGlobalVariables) &&
+            (!value.removeProtectedGlobalVariables) &&
             (!value.removeLocalVariables) &&
             (!value.removeLocalMethodParameters)));
     }
 
     protected copySettings(dest: any, src: any) {
-        if (!src)
+        if (!src) {
             src = {};
+        }
         dest.removeGlobalVariables = !!src.removeGlobalVariables;
+        dest.removeProtectedGlobalVariables = !!src.removeProtectedGlobalVariables;
         dest.removeLocalVariables = !!src.removeLocalVariables;
         dest.removeLocalMethodParameters = !!src.removeLocalMethodParameters;
     }
 
     protected loadDefaultParameters(uri: vscode.Uri | undefined): boolean {
         let defaultParameters = vscode.workspace.getConfiguration('alOutline', uri).get<IRemoveUnusedVariablesSettings>('defaultRemoveUnusedVariablesSettings');
-        if (this.areSettingsEmpty(defaultParameters))
+        if (this.areSettingsEmpty(defaultParameters)) {
             return false;
+        }
+
+        //get state from previous versions of the extension (global variables and protected global variables were using the same setting in previous versions)
+        if ((defaultParameters) && (defaultParameters.removeProtectedGlobalVariables === undefined)) {
+            defaultParameters.removeProtectedGlobalVariables = defaultParameters.removeGlobalVariables;
+        }
+
         this.copySettings(this._variableTypes, defaultParameters);
         return true;
     }
@@ -49,6 +60,7 @@ export class RemoveUnusedVariablesModifier extends WorkspaceCommandSyntaxModifie
         this.loadState();
         let quickPickItems = [
             new NameValueQuickPickItem('Global variables', 'removeGlobalVariables', !!this._variableTypes.removeGlobalVariables),
+            new NameValueQuickPickItem('Protected global variables', 'removeProtectedGlobalVariables', !!this._variableTypes.removeProtectedGlobalVariables),
             new NameValueQuickPickItem('Local variables', 'removeLocalVariables', !!this._variableTypes.removeLocalVariables),
             new NameValueQuickPickItem('Local methods parameters', 'removeLocalMethodParameters', !!this._variableTypes.removeLocalMethodParameters)
         ];
@@ -56,8 +68,9 @@ export class RemoveUnusedVariablesModifier extends WorkspaceCommandSyntaxModifie
         let selectedValues = await vscode.window.showQuickPick(
             quickPickItems, { canPickMany: true, placeHolder: 'Select variables to remove' });
 
-        if (!selectedValues)
+        if (!selectedValues) {
             return false;
+        }
 
         this.clearVariableTypes();
         let data: any = {};
@@ -66,8 +79,9 @@ export class RemoveUnusedVariablesModifier extends WorkspaceCommandSyntaxModifie
                 data[selectedValues[i].value] = true;
             }
         }
-        if (this.areSettingsEmpty(data))
+        if (this.areSettingsEmpty(data)) {
             return false;
+        }
             
         this.copySettings(this._variableTypes, data);
         this.saveState();
@@ -80,12 +94,22 @@ export class RemoveUnusedVariablesModifier extends WorkspaceCommandSyntaxModifie
         this._variableTypes.removeGlobalVariables = !!vsctx.globalState.get<boolean>("azALDevTools.remUVar.removeGlobalVariables");
         this._variableTypes.removeLocalVariables = !!vsctx.globalState.get<boolean>("azALDevTools.remUVar.removeLocalVariables");
         this._variableTypes.removeLocalMethodParameters = !!vsctx.globalState.get<boolean>("azALDevTools.remUVar.removeLocalMethodParameters");
+
+        //get state from previous versions of the extension (global variables and protected global variables were using the same setting in previous versions)
+        let removeProtectedVariables = vsctx.globalState.get<boolean>("azALDevTools.remUVar.removeProtectedGlobalVariables");
+        if (removeProtectedVariables === undefined) {
+            removeProtectedVariables = this._variableTypes.removeGlobalVariables;
+        }
+        this._variableTypes.removeProtectedGlobalVariables = !!removeProtectedVariables;
+
         //set defaults
         if ((!this._variableTypes.removeGlobalVariables) &&
+            (!this._variableTypes.removeProtectedGlobalVariables) &&
             (!this._variableTypes.removeLocalVariables) &&
             (!this._variableTypes.removeLocalMethodParameters)) {
 
             this._variableTypes.removeGlobalVariables = true;
+            this._variableTypes.removeProtectedGlobalVariables = true;
             this._variableTypes.removeLocalVariables = true;
             this._variableTypes.removeLocalMethodParameters = false;
         }
@@ -94,12 +118,14 @@ export class RemoveUnusedVariablesModifier extends WorkspaceCommandSyntaxModifie
     private saveState() {
         let vsctx = this._context.vscodeExtensionContext;
         vsctx.globalState.update("azALDevTools.remUVar.removeGlobalVariables", !!this._variableTypes.removeGlobalVariables);
+        vsctx.globalState.update("azALDevTools.remUVar.removeProtectedGlobalVariables", !!this._variableTypes.removeProtectedGlobalVariables);
         vsctx.globalState.update("azALDevTools.remUVar.removeLocalVariables", !!this._variableTypes.removeLocalVariables);
         vsctx.globalState.update("azALDevTools.remUVar.removeLocalMethodParameters", !!this._variableTypes.removeLocalMethodParameters);
     }
 
     private clearVariableTypes() {
         this._variableTypes.removeGlobalVariables = false;
+        this._variableTypes.removeProtectedGlobalVariables = false;
         this._variableTypes.removeLocalVariables = false;
         this._variableTypes.removeLocalMethodParameters = false;
     }

--- a/vscode-extension/src/alsyntaxmodifiers/sortProceduresOrTriggersModifier.ts
+++ b/vscode-extension/src/alsyntaxmodifiers/sortProceduresOrTriggersModifier.ts
@@ -12,9 +12,9 @@ export class SortProceduresOrTriggersModifier extends WorkspaceCommandSyntaxModi
         let parameters = super.getParameters(uri);
         let settings = vscode.workspace.getConfiguration('alOutline', uri);                
         parameters.triggersSortMode = settings.get<string>('triggersSortMode');
+        parameters.globalVariablesSortMode = settings.get<string>('sortMembersGlobalVariablesSortMode');
         parameters.triggersNaturalOrder = JSON.stringify(settings.get('triggersNaturalOrder'));
         parameters.sortSingleNodeRegions = !!settings.get<boolean>('sortSingleNodeRegions');
-        parameters.globalVariablesAfterTriggers = !!settings.get<boolean>('sortMembersPutGlobalVariablesAfterTriggers');
         return parameters;
     }
 

--- a/vscode-extension/src/alsyntaxmodifiers/sortProceduresOrTriggersModifier.ts
+++ b/vscode-extension/src/alsyntaxmodifiers/sortProceduresOrTriggersModifier.ts
@@ -14,6 +14,7 @@ export class SortProceduresOrTriggersModifier extends WorkspaceCommandSyntaxModi
         parameters.triggersSortMode = settings.get<string>('triggersSortMode');
         parameters.triggersNaturalOrder = JSON.stringify(settings.get('triggersNaturalOrder'));
         parameters.sortSingleNodeRegions = !!settings.get<boolean>('sortSingleNodeRegions');
+        parameters.globalVariablesAfterTriggers = !!settings.get<boolean>('sortMembersPutGlobalVariablesAfterTriggers');
         return parameters;
     }
 

--- a/vscode-extension/src/objectwizards/wizards/alEnumWizard.ts
+++ b/vscode-extension/src/objectwizards/wizards/alEnumWizard.ts
@@ -1,5 +1,4 @@
-'use strict';
-
+import * as vscode from 'vscode';
 import { ALObjectWizard } from "./alObjectWizard";
 import { ALEnumWizardData } from "./alEnumWizardData";
 import { ALEnumWizardPage } from "./alEnumWizardPage";
@@ -18,8 +17,14 @@ export class ALEnumWizard extends ALObjectWizard {
     }
 
     protected async runAsync(settings: ALObjectWizardSettings) {
+        let uri = settings.getDestDirectoryUri();        
+        let vscodeSettings = vscode.workspace.getConfiguration('alOutline', uri);
         let wizardData : ALEnumWizardData = new ALEnumWizardData();
+
+        wizardData.limitNameLength = !!vscodeSettings.get<boolean>('limitEnumNameLength');
+
         await this.initObjectIdFieldsAsync(wizardData, settings, "enum");
+        
         wizardData.objectName = '';
         this.onInitWizardData(wizardData);
         let wizardPage : ALEnumWizardPage = new ALEnumWizardPage(this._toolsExtensionContext, settings, wizardData);

--- a/vscode-extension/src/objectwizards/wizards/alEnumWizardData.ts
+++ b/vscode-extension/src/objectwizards/wizards/alEnumWizardData.ts
@@ -5,6 +5,7 @@ export class ALEnumWizardData extends ALObjectWizardData {
     valueList : string;
     captionList : string;
     extensible : boolean;
+    limitNameLength : boolean;
     
     constructor() {
         super();
@@ -12,6 +13,7 @@ export class ALEnumWizardData extends ALObjectWizardData {
         this.valueList = "";
         this.captionList = "";
         this.extensible = true;
+        this.limitNameLength = false;
     }
 
 } 


### PR DESCRIPTION
 - Issue #535 - Separate 'Sort Triggers' action - sorting fixes and improvements
 - Issue #590 - Delete unused variables with obsolete tag 
   - "Remove global variables" settings split into separate "Remove global variables" and "Remove protected global variables" settings
     - `removeProtectedGlobalVariables` property added to the `defaultRemoveUnusedVariablesSetting` setting
 - Issue #591 - Limit Enum Object Names to 30 Chars in AL File Wizard
 - Issue #592 - Remove redundant ApplicationArea adds unnecessary quotes 