### PR TITLE
feat: Add AL Symbols Browser language model tool for Copilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 16.78.0
 
+ - New AL Symbols Browser language model tool for GitHub Copilot integration - allows AI assistants to search and browse AL project symbols (tables, pages, codeunits, etc.) with filtering, dependency inclusion, and source code resolution
+ - VS Code engine minimum version bumped to 1.95.0
+ - Tree view icon paths fixed to use vscode.Uri (warning directives, duplicate code, AL outline)
  - Issues #652, #653, #654, #655 -  BC27 fixes
 
  Thank you

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "al-code-outline",
-			"version": "3.0.56",
+			"version": "16.78.0",
 			"license": "MIT",
 			"dependencies": {
 				"vscode-jsonrpc": "^8.2.0",
@@ -15,7 +15,7 @@
 			"devDependencies": {
 				"@types/mocha": "^10.0.6",
 				"@types/node": "18.x",
-				"@types/vscode": "^1.85.0",
+				"@types/vscode": "^1.95.0",
 				"@typescript-eslint/eslint-plugin": "^6.15.0",
 				"@typescript-eslint/parser": "^6.15.0",
 				"@vscode/test-cli": "^0.0.4",
@@ -24,7 +24,7 @@
 				"typescript": "^5.3.3"
 			},
 			"engines": {
-				"vscode": "^1.85.0"
+				"vscode": "^1.95.0"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -295,10 +295,11 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.85.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.85.0.tgz",
-			"integrity": "sha512-CF/RBon/GXwdfmnjZj0WTUMZN5H6YITOfBCP4iEZlOtVQXuzw6t7Le7+cR+7JzdMrnlm7Mfp49Oj2TuSXIWo3g==",
-			"dev": true
+			"version": "1.110.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.110.0.tgz",
+			"integrity": "sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "6.16.0",
@@ -340,6 +341,7 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.16.0.tgz",
 			"integrity": "sha512-H2GM3eUo12HpKZU9njig3DF5zJ58ja6ahj1GoHEHOgQvYxzoFJJEvC1MQ7T2l9Ha+69ZSOn7RTxOdpC/y3ikMw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "6.16.0",
 				"@typescript-eslint/types": "6.16.0",
@@ -534,6 +536,7 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
 			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
 			"dev": true,
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -956,6 +959,7 @@
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
 			"integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
@@ -2546,6 +2550,7 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
 			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
 			"dev": true,
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -5,7 +5,7 @@
 	"version": "16.78.0",
 	"publisher": "andrzejzwierzchowski",
 	"engines": {
-		"vscode": "^1.85.0"
+		"vscode": "^1.95.0"
 	},
 	"author": {
 		"name": "Andrzej Zwierzchowski",
@@ -1401,17 +1401,86 @@
 				]
 			}
 		],
+		"languageModelTools": [
+			{
+				"name": "azALDevTools_symbolsBrowser",
+				"displayName": "AL Symbols Browser",
+				"toolReferenceName": "alSymbolsBrowser",
+				"icon": "$(symbol-class)",
+				"canBeReferencedInPrompt": true,
+				"modelDescription": "Search and browse AL (Business Central) project symbols such as tables, pages, codeunits, reports, queries, xmlports, enums, interfaces, and extensions. Supports wildcard name filtering (e.g. *Customer*), filtering by symbol kind, and optionally including dependency symbols and child members. Returns a formatted list of matching AL objects with their kind, id, name, source, and optionally their fields, methods, triggers, and other child elements.",
+				"inputSchema": {
+					"type": "object",
+					"properties": {
+						"query": {
+							"type": "string",
+							"description": "Wildcard name filter to match symbol names, e.g. '*Customer*', '*Item*', 'Sales*'. Use * for any characters, ? for a single character."
+						},
+						"symbolKind": {
+							"type": "string",
+							"description": "Filter by AL object kind. Use 'all' or omit to return all kinds.",
+							"enum": [
+								"all",
+								"table",
+								"page",
+								"codeunit",
+								"report",
+								"query",
+								"xmlport",
+								"enum",
+								"interface",
+								"tableExtension",
+								"pageExtension",
+								"enumExtension",
+								"reportExtension",
+								"permissionSet",
+								"permissionSetExtension",
+								"profile",
+								"pageCustomization",
+								"controlAddIn",
+								"dotNetPackage",
+								"entitlement"
+							]
+						},
+						"includeDependencies": {
+							"type": "boolean",
+							"default": true,
+							"description": "Whether to include symbols from dependency apps. Defaults to true."
+						},
+						"includeBody": {
+							"type": "boolean",
+							"default": false,
+							"description": "Whether to include child members (fields, methods, triggers, etc.) in the output. Defaults to false."
+						},
+						"includeSourceCode": {
+							"type": "boolean",
+							"default": false,
+							"description": "Whether to resolve and return the full AL source code for each matched symbol. Works for project files and dependency .app packages. Defaults to false."
+						},
+						"maxResults": {
+							"type": "number",
+							"default": 50,
+							"description": "Maximum number of symbols to return. Defaults to 50."
+						},
+						"workspaceFolderPath": {
+							"type": "string",
+							"description": "Absolute path to the AL workspace folder. If omitted, uses the current active workspace folder."
+						}
+					}
+				}
+			}
+		],
 		"configuration": [
 			{
 				"title": "AZ AL Dev Tools/AL Code Outline",
 				"properties": {
-					"alOutline.activeBuildConfiguration" : {
+					"alOutline.activeBuildConfiguration": {
 						"type": "string",
 						"default": "",
 						"scope": "resource",
 						"description": "Name of the active build configuration (active app.json file) for the workspace folder"
 					},
-					"alOutline.buildConfigurationNaming" : {
+					"alOutline.buildConfigurationNaming": {
 						"type": "string",
 						"default": "none",
 						"scope": "resource",
@@ -1429,7 +1498,7 @@
 							"app.json.<configuration name>"
 						]
 					},
-					"alOutline.limitEnumNameLength" : {
+					"alOutline.limitEnumNameLength": {
 						"type": "boolean",
 						"default": false,
 						"scope": "resource",
@@ -2184,7 +2253,7 @@
 	"devDependencies": {
 		"@types/mocha": "^10.0.6",
 		"@types/node": "18.x",
-		"@types/vscode": "^1.85.0",
+		"@types/vscode": "^1.95.0",
 		"@typescript-eslint/eslint-plugin": "^6.15.0",
 		"@typescript-eslint/parser": "^6.15.0",
 		"@vscode/test-cli": "^0.0.4",

--- a/vscode-extension/src/codeanalyzers/warningDirectivesTreeProvider.ts
+++ b/vscode-extension/src/codeanalyzers/warningDirectivesTreeProvider.ts
@@ -53,7 +53,7 @@ export class WarningDirectivesTreeProvider implements vscode.TreeDataProvider<Wa
         return directives;
     }
 
-    private getNodeIcon(info: WarningDirectiveInfo) : { light: string, dark: string } | undefined {
+    private getNodeIcon(info: WarningDirectiveInfo) : { light: vscode.Uri, dark: vscode.Uri } | undefined {
         switch (info.kind) {
             case WarningDirectiveInfoKind.Project:
                 return this.getIcon("tree-project.svg");
@@ -70,10 +70,10 @@ export class WarningDirectivesTreeProvider implements vscode.TreeDataProvider<Wa
         return undefined;
     }
 
-    private getIcon(fileName: string) : { light: string, dark: string } {
+    private getIcon(fileName: string) : { light: vscode.Uri, dark: vscode.Uri } {
         return {
-            light: this._toolsExtensionContext.vscodeExtensionContext.asAbsolutePath(path.join("resources", "images", "light", fileName)),
-            dark: this._toolsExtensionContext.vscodeExtensionContext.asAbsolutePath(path.join("resources", "images", "dark", fileName))
+            light: vscode.Uri.file(this._toolsExtensionContext.vscodeExtensionContext.asAbsolutePath(path.join("resources", "images", "light", fileName))),
+            dark: vscode.Uri.file(this._toolsExtensionContext.vscodeExtensionContext.asAbsolutePath(path.join("resources", "images", "dark", fileName)))
         };
     }
 

--- a/vscode-extension/src/devToolsExtensionContext.ts
+++ b/vscode-extension/src/devToolsExtensionContext.ts
@@ -28,6 +28,7 @@ import { IdReservationService } from './services/idReservationService';
 import { ALDecorationService } from './services/alDecorationService';
 import { GitClientService } from './services/gitClientService';
 import { ALBuildConfigurationService } from './configmanager/ALBuildConfigurationService';
+import { ALSymbolsBrowserTool } from './services/alSymbolsBrowserTool';
 
 export class DevToolsExtensionContext implements vscode.Disposable {
     alLangProxy : ALLangServerProxy;    
@@ -88,6 +89,10 @@ export class DevToolsExtensionContext implements vscode.Disposable {
         this.alDecorationService = new ALDecorationService(this);
         this.gitService = new GitClientService(this);
         this.buildConfigurationService = new ALBuildConfigurationService(this);
+
+        if (vscode.lm && vscode.lm.registerTool) {
+            context.subscriptions.push(vscode.lm.registerTool('azALDevTools_symbolsBrowser', new ALSymbolsBrowserTool(this)));
+        }
     }
 
     getUseSymbolsBrowser() : boolean {

--- a/vscode-extension/src/duplicatecode/duplicateCodeTreeProvider.ts
+++ b/vscode-extension/src/duplicatecode/duplicateCodeTreeProvider.ts
@@ -92,7 +92,7 @@ export class DuplicateCodeTreeProvider implements vscode.TreeDataProvider<Duplic
         return 'Code';
     }
 
-    protected getGroupIcon(info: DuplicateInfo): { light: string, dark: string } {
+    protected getGroupIcon(info: DuplicateInfo): { light: vscode.Uri, dark: vscode.Uri } {
         switch (info.codeBlockType) {
             case CodeBlockType.Method:
                 return this.getIcon('tree-method.svg');
@@ -152,10 +152,10 @@ export class DuplicateCodeTreeProvider implements vscode.TreeDataProvider<Duplic
         return undefined;
     }
 
-    private getIcon(fileName: string) : { light: string, dark: string } {
+    private getIcon(fileName: string) : { light: vscode.Uri, dark: vscode.Uri } {
         return {
-            light: this._toolsExtensionContext.vscodeExtensionContext.asAbsolutePath(path.join("resources", "images", "light", fileName)),
-            dark: this._toolsExtensionContext.vscodeExtensionContext.asAbsolutePath(path.join("resources", "images", "dark", fileName))
+            light: vscode.Uri.file(this._toolsExtensionContext.vscodeExtensionContext.asAbsolutePath(path.join("resources", "images", "light", fileName))),
+            dark: vscode.Uri.file(this._toolsExtensionContext.vscodeExtensionContext.asAbsolutePath(path.join("resources", "images", "dark", fileName)))
         };
     }
 

--- a/vscode-extension/src/outlineview/alOutlineTreeNode.ts
+++ b/vscode-extension/src/outlineview/alOutlineTreeNode.ts
@@ -84,8 +84,8 @@ export class ALOutlineTreeItem extends vscode.TreeItem {
     private updateIcon(context: vscode.ExtensionContext) {
         let icon = "tree-" + this.symbol.icon + ".svg";
         this.iconPath = {
-            light: context.asAbsolutePath(path.join("resources", "images", "light", icon)),
-            dark: context.asAbsolutePath(path.join("resources", "images", "dark", icon))
+            light: vscode.Uri.file(context.asAbsolutePath(path.join("resources", "images", "light", icon))),
+            dark: vscode.Uri.file(context.asAbsolutePath(path.join("resources", "images", "dark", icon)))
         }
     }
 

--- a/vscode-extension/src/services/alSymbolsBrowserTool.ts
+++ b/vscode-extension/src/services/alSymbolsBrowserTool.ts
@@ -1,0 +1,309 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import { ALProjectSymbolsLibrary } from '../symbollibraries/alProjectSymbolsLibrary';
+import { AZSymbolInformation } from '../symbollibraries/azSymbolInformation';
+import { AZSymbolKind } from '../symbollibraries/azSymbolKind';
+import { DevToolsExtensionContext } from '../devToolsExtensionContext';
+import { ToolsGetProjectSymbolLocationRequest } from '../langserver/toolsGetProjectSymbolLocationRequest';
+import { ToolsGetALAppContentRequest } from '../langserver/toolsGetALAppContentRequest';
+
+interface ALSymbolsBrowserToolInput {
+    query?: string;
+    symbolKind?: string;
+    includeDependencies?: boolean;
+    includeBody?: boolean;
+    includeSourceCode?: boolean;
+    maxResults?: number;
+    workspaceFolderPath?: string;
+}
+
+const SYMBOL_KIND_MAP: { [key: string]: AZSymbolKind[] } = {
+    'table': [AZSymbolKind.TableObject],
+    'page': [AZSymbolKind.PageObject],
+    'codeunit': [AZSymbolKind.CodeunitObject],
+    'report': [AZSymbolKind.ReportObject],
+    'query': [AZSymbolKind.QueryObject],
+    'xmlport': [AZSymbolKind.XmlPortObject],
+    'enum': [AZSymbolKind.EnumType],
+    'interface': [AZSymbolKind.Interface],
+    'tableExtension': [AZSymbolKind.TableExtensionObject],
+    'pageExtension': [AZSymbolKind.PageExtensionObject],
+    'enumExtension': [AZSymbolKind.EnumExtensionType],
+    'reportExtension': [AZSymbolKind.ReportExtensionObject],
+    'permissionSet': [AZSymbolKind.PermissionSet],
+    'permissionSetExtension': [AZSymbolKind.PermissionSetExtension],
+    'profile': [AZSymbolKind.ProfileObject],
+    'pageCustomization': [AZSymbolKind.PageCustomizationObject],
+    'controlAddIn': [AZSymbolKind.ControlAddInObject],
+    'dotNetPackage': [AZSymbolKind.DotNetPackage],
+    'entitlement': [AZSymbolKind.Entitlement],
+};
+
+export class ALSymbolsBrowserTool implements vscode.LanguageModelTool<ALSymbolsBrowserToolInput> {
+    protected _context : DevToolsExtensionContext;
+
+    constructor(context : DevToolsExtensionContext) {
+        this._context = context;
+    }
+
+    async invoke(options : vscode.LanguageModelToolInvocationOptions<ALSymbolsBrowserToolInput>, token : vscode.CancellationToken) : Promise<vscode.LanguageModelToolResult> {
+        let input = options.input;
+        let includeDeps = input.includeDependencies !== false;
+        let includeBody = input.includeBody === true;
+        let maxResults = (input.maxResults) ? input.maxResults : 50;
+        let query = (input.query) ? input.query.trim() : undefined;
+        let kindFilter = (input.symbolKind) ? input.symbolKind.trim() : undefined;
+
+        let workspacePath = (input.workspaceFolderPath) ? input.workspaceFolderPath : this._context.alLangProxy.getCurrentWorkspaceFolderPath();
+        if (!workspacePath) {
+            return new vscode.LanguageModelToolResult([
+                new vscode.LanguageModelTextPart('No AL workspace folder is currently open.')
+            ]);
+        }
+
+        let lib = new ALProjectSymbolsLibrary(this._context, includeDeps, workspacePath);
+        let loaded = await lib.loadAsync(true);
+
+        if (!loaded || !lib.rootSymbol) {
+            return new vscode.LanguageModelToolResult([
+                new vscode.LanguageModelTextPart('Failed to load project symbols. Make sure the AL Language extension is active and the project compiles.')
+            ]);
+        }
+
+        if (token.isCancellationRequested) {
+            return new vscode.LanguageModelToolResult([
+                new vscode.LanguageModelTextPart('Operation cancelled.')
+            ]);
+        }
+
+        //collect all AL objects from the symbol tree
+        let allObjects : AZSymbolInformation[] = [];
+        lib.rootSymbol.collectObjectSymbols(allObjects);
+
+        //filter by kind
+        if ((kindFilter) && (kindFilter !== 'all')) {
+            let allowedKinds = SYMBOL_KIND_MAP[kindFilter];
+            if (allowedKinds) {
+                allObjects = allObjects.filter(s => allowedKinds.indexOf(s.kind) >= 0);
+            }
+        }
+
+        //filter by name query (supports wildcards)
+        if (query) {
+            let pattern = this.wildcardToRegex(query);
+            allObjects = allObjects.filter(s => pattern.test(s.name) || pattern.test(s.fullName));
+        }
+
+        //limit results
+        let totalCount = allObjects.length;
+        let truncated = allObjects.length > maxResults;
+        if (truncated) {
+            allObjects = allObjects.slice(0, maxResults);
+        }
+
+        if (allObjects.length === 0) {
+            return new vscode.LanguageModelToolResult([
+                new vscode.LanguageModelTextPart('No symbols found matching the given criteria.')
+            ]);
+        }
+
+        //format output
+        let lines : string[] = [];
+        lines.push('Found ' + totalCount.toString() + ' symbol(s)' + (truncated ? ' (showing first ' + maxResults.toString() + ')' : '') + ':\n');
+        for (let i=0; i<allObjects.length; i++) {
+            lines.push(this.formatSymbol(allObjects[i], includeBody, 0));
+        }
+
+        //resolve and include source code if requested
+        if (input.includeSourceCode) {
+            let workspaceFolders = vscode.workspace.workspaceFolders;
+            let workspaceFolder : vscode.WorkspaceFolder | undefined = undefined;
+            if (workspaceFolders) {
+                for (let i=0; i<workspaceFolders.length; i++) {
+                    if (workspacePath.startsWith(workspaceFolders[i].uri.fsPath)) {
+                        workspaceFolder = workspaceFolders[i];
+                        break;
+                    }
+                }
+                if (!workspaceFolder)
+                    workspaceFolder = workspaceFolders[0];
+            }
+
+            let libraryUri = lib.getUri();
+            let libraryPath : string | undefined = undefined;
+            if (libraryUri)
+                libraryPath = libraryUri.fsPath;
+
+            for (let i=0; i<allObjects.length; i++) {
+                let sourceCode = await this.resolveSourceCode(allObjects[i], workspacePath, libraryPath, workspaceFolder);
+                if (sourceCode) {
+                    let objId = allObjects[i].id ? ' ' + allObjects[i].id.toString() : '';
+                    lines.push('\n--- Source: ' + allObjects[i].getObjectTypeName() + objId + ' "' + allObjects[i].name + '" ---');
+                    lines.push(sourceCode);
+                }
+            }
+        }
+
+        return new vscode.LanguageModelToolResult([
+            new vscode.LanguageModelTextPart(lines.join('\n'))
+        ]);
+    }
+
+    async prepareInvocation(options : vscode.LanguageModelToolInvocationPrepareOptions<ALSymbolsBrowserToolInput>, _token : vscode.CancellationToken) : Promise<vscode.PreparedToolInvocation> {
+        let input = options.input;
+        let message = 'Browsing AL project symbols';
+        if (input.query) {
+            message += ' matching "' + input.query + '"';
+        }
+        if ((input.symbolKind) && (input.symbolKind !== 'all')) {
+            message += ' (kind: ' + input.symbolKind + ')';
+        }
+        return { invocationMessage: message };
+    }
+
+    protected formatSymbol(symbol : AZSymbolInformation, includeChildren : boolean, indent : number) : string {
+        let prefix = '  '.repeat(indent);
+        let kindName = symbol.getObjectTypeName();
+        let id = symbol.id ? ' ' + symbol.id.toString() : '';
+        let ext = symbol.extends ? ' extends "' + symbol.extends + '"' : '';
+        let src = symbol.source ? ' [' + symbol.source + ']' : '';
+        let line = prefix + '- ' + kindName + id + ' "' + symbol.name + '"' + ext + src;
+        if ((includeChildren) && (symbol.childSymbols)) {
+            for (let i=0; i<symbol.childSymbols.length; i++) {
+                line += '\n' + this.formatChildSymbol(symbol.childSymbols[i], indent + 1);
+            }
+        }
+        return line;
+    }
+
+    protected formatChildSymbol(symbol : AZSymbolInformation, indent : number) : string {
+        let prefix = '  '.repeat(indent);
+        let kindLabel = this.getChildKindLabel(symbol);
+        let line = prefix + '- [' + kindLabel + '] "' + symbol.name + '"';
+        if (symbol.childSymbols) {
+            for (let i=0; i<symbol.childSymbols.length; i++) {
+                line += '\n' + this.formatChildSymbol(symbol.childSymbols[i], indent + 1);
+            }
+        }
+        return line;
+    }
+
+    protected getChildKindLabel(symbol : AZSymbolInformation) : string {
+        if (symbol.isMethod()) return 'Method';
+        if (symbol.isTrigger()) return 'Trigger';
+        switch (symbol.kind) {
+            case AZSymbolKind.Field: return 'Field';
+            case AZSymbolKind.Key: return 'Key';
+            case AZSymbolKind.PrimaryKey: return 'PrimaryKey';
+            case AZSymbolKind.FieldGroup: return 'FieldGroup';
+            case AZSymbolKind.PageField: return 'PageField';
+            case AZSymbolKind.PageAction: return 'Action';
+            case AZSymbolKind.PageActionGroup: return 'ActionGroup';
+            case AZSymbolKind.PageGroup: return 'Group';
+            case AZSymbolKind.PageArea: return 'Area';
+            case AZSymbolKind.PagePart: return 'Part';
+            case AZSymbolKind.PageLayout: return 'Layout';
+            case AZSymbolKind.PageActionList: return 'Actions';
+            case AZSymbolKind.PageRepeater: return 'Repeater';
+            case AZSymbolKind.ReportDataItem: return 'DataItem';
+            case AZSymbolKind.ReportColumn: return 'Column';
+            case AZSymbolKind.ReportLabel: return 'Label';
+            case AZSymbolKind.ReportLabelMultilanguage: return 'Label';
+            case AZSymbolKind.ReportDataSetSection: return 'DataSet';
+            case AZSymbolKind.ReportLabelsSection: return 'Labels';
+            case AZSymbolKind.QueryDataItem: return 'DataItem';
+            case AZSymbolKind.QueryColumn: return 'Column';
+            case AZSymbolKind.QueryFilter: return 'Filter';
+            case AZSymbolKind.EnumValue: return 'Value';
+            case AZSymbolKind.XmlPortTableElement: return 'TableElement';
+            case AZSymbolKind.XmlPortFieldElement: return 'FieldElement';
+            case AZSymbolKind.XmlPortFieldAttribute: return 'FieldAttribute';
+            case AZSymbolKind.XmlPortTextElement: return 'TextElement';
+            case AZSymbolKind.XmlPortTextAttribute: return 'TextAttribute';
+            case AZSymbolKind.XmlPortSchema: return 'Schema';
+            case AZSymbolKind.VariableDeclaration:
+            case AZSymbolKind.VariableDeclarationName: return 'Variable';
+            case AZSymbolKind.VarSection:
+            case AZSymbolKind.GlobalVarSection: return 'Variables';
+            case AZSymbolKind.Property: return 'Property';
+            case AZSymbolKind.PropertyList: return 'Properties';
+            case AZSymbolKind.Parameter: return 'Parameter';
+            case AZSymbolKind.ParameterList: return 'Parameters';
+            case AZSymbolKind.FieldList: return 'Fields';
+            case AZSymbolKind.KeyList: return 'Keys';
+            case AZSymbolKind.FieldGroupList: return 'FieldGroups';
+            case AZSymbolKind.FieldExtensionList: return 'FieldChanges';
+            case AZSymbolKind.PageViewList:
+            case AZSymbolKind.PageExtensionViewList: return 'Views';
+            case AZSymbolKind.PageActionArea:
+            case AZSymbolKind.PageExtensionActionList: return 'ActionArea';
+            case AZSymbolKind.RequestPage:
+            case AZSymbolKind.RequestPageExtension: return 'RequestPage';
+            case AZSymbolKind.Region: return 'Region';
+            case AZSymbolKind.DotNetAssembly: return 'Assembly';
+            case AZSymbolKind.DotNetTypeDeclaration: return 'Type';
+            case AZSymbolKind.EventDeclaration: return 'Event';
+            case AZSymbolKind.IntegrationEventDeclaration: return 'IntegrationEvent';
+            case AZSymbolKind.InternalEventDeclaration: return 'InternalEvent';
+            case AZSymbolKind.BusinessEventDeclaration: return 'BusinessEvent';
+            case AZSymbolKind.ExternalBusinessEventDeclaration: return 'ExternalBusinessEvent';
+            case AZSymbolKind.EventSubscriberDeclaration: return 'EventSubscriber';
+            default: return AZSymbolKind[symbol.kind] || 'Symbol';
+        }
+    }
+
+    protected async resolveSourceCode(symbol : AZSymbolInformation, workspacePath : string,
+        libraryPath : string | undefined, workspaceFolder : vscode.WorkspaceFolder | undefined) : Promise<string | undefined> {
+        if (!workspaceFolder)
+            return undefined;
+
+        let locationResponse = await this._context.toolsLangServerClient.getProjectSymbolLocation(
+            new ToolsGetProjectSymbolLocationRequest(
+                workspaceFolder.uri.fsPath, libraryPath, symbol.kind.toString(), symbol.name));
+
+        if ((!locationResponse) || (!locationResponse.location))
+            return undefined;
+
+        let location = locationResponse.location;
+        if ((!location.schema) || (!location.sourcePath))
+            return undefined;
+
+        if (location.schema === 'file') {
+            try {
+                let content = fs.readFileSync(location.sourcePath, 'utf8');
+                return content;
+            } catch {
+                return undefined;
+            }
+        } else if (location.schema === 'alapp') {
+            let pathParts = location.sourcePath.split('::');
+            if (pathParts.length >= 2) {
+                let appPath = pathParts[0];
+                let filePath = pathParts.slice(1).join('::');
+                let contentResponse = await this._context.toolsLangServerClient.getALAppContent(
+                    new ToolsGetALAppContentRequest(appPath, filePath));
+                if ((contentResponse) && (contentResponse.source))
+                    return contentResponse.source;
+            }
+        } else if (location.schema === 'al-preview') {
+            try {
+                let previewUri = vscode.Uri.parse(
+                    'al-preview://allang/' + workspaceFolder.name + '/' + encodeURIComponent(location.sourcePath));
+                let doc = await vscode.workspace.openTextDocument(previewUri);
+                return doc.getText();
+            } catch {
+                return undefined;
+            }
+        }
+
+        return undefined;
+    }
+
+    protected wildcardToRegex(pattern : string) : RegExp {
+        let escaped = pattern.replace(/([.+^${}()|[\]\\])/g, '\\$1');
+        let regexStr = escaped.replace(/\*/g, '.*').replace(/\?/g, '.');
+        return new RegExp('^' + regexStr + '$', 'i');
+    }
+}


### PR DESCRIPTION
- New ALSymbolsBrowserTool implementing vscode.LanguageModelTool API
  enabling AI assistants to search/browse AL project symbols with
  filtering by name (wildcards), symbol kind, dependency inclusion,
  child members, and source code resolution
- Register tool via vscode.lm.registerTool in extension activation
- Declare languageModelTools contribution point in package.json
- Bump VS Code engine minimum to 1.95.0 for lm.registerTool API
- Fix tree view icon paths to use vscode.Uri in warningDirectives,
  duplicateCode, and alOutlineTreeNode providers